### PR TITLE
Hbtemplatecachework

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-	ext.kotlin_version = '1.3.41'
+	ext.kotlin_version = '1.3.61'
 	ext.handlebars_version = '4.1.2'
 	ext.slf4j_version = '1.7.26'
 	ext.flexmark_version = '0.42.0'
@@ -16,7 +16,7 @@ buildscript {
 }
 
 plugins {
-	id 'org.jetbrains.kotlin.jvm' version '1.3.41'
+	id 'org.jetbrains.kotlin.jvm' version '1.3.60'
 	id 'com.github.johnrengelman.shadow' version '4.0.3'
 }
 
@@ -62,7 +62,7 @@ dependencies {
 	compile 'org.koin:koin-core:1.0.0-RC-3'
 	
 	// kotlinx serialization, for document caching
-	compile 'org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.11.1'
+	compile 'org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0'
 //	compile 'org.jetbrains.kotlinx:kotlinx-gradle-serialization-plugin:0.6.2'
 
 	// for console progress bar?

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 }
 
 plugins {
-	id 'org.jetbrains.kotlin.jvm' version '1.3.60'
+	id 'org.jetbrains.kotlin.jvm' version '1.3.61'
 	id 'com.github.johnrengelman.shadow' version '4.0.3'
 }
 
@@ -38,7 +38,7 @@ dependencies {
 	compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: '1.0.1'
 	
 	// bascule library
-	compile group: 'org.liamjd.bascule-lib', name: 'bascule-lib', version: '0.0.19'
+	compile group: 'org.liamjd.bascule-lib', name: 'bascule-lib', version: '0.0.20'
 
 	// handlebars templating
 	compile group: 'com.github.jknack', name: 'handlebars', version: "$handlebars_version"

--- a/src/main/kotlin/org/liamjd/bascule/BasculeFileHandler.kt
+++ b/src/main/kotlin/org/liamjd/bascule/BasculeFileHandler.kt
@@ -1,12 +1,17 @@
 package org.liamjd.bascule
 
 import mu.KotlinLogging
+import org.liamjd.bascule.cache.HandlebarsTemplateCacheItem
 import org.liamjd.bascule.lib.FileHandler
 import java.io.BufferedReader
 import java.io.File
+import java.io.FileFilter
 import java.io.FileNotFoundException
 import java.io.InputStream
 import java.nio.file.FileSystems
+import java.time.Instant
+import java.time.LocalDateTime
+import java.util.*
 
 /**
  * File handling utility for creating files and directories, extracting files from resources, etc.
@@ -141,5 +146,4 @@ class BasculeFileHandler : FileHandler {
 		val file = File(fileName)
 		return readFileAsString(file.parentFile,file.name)
 	}
-
-}
+	}

--- a/src/main/kotlin/org/liamjd/bascule/Constants.kt
+++ b/src/main/kotlin/org/liamjd/bascule/Constants.kt
@@ -21,7 +21,7 @@ fun String.slug() : String {
  * Various final values. Extension functions. Plus logos :)
  */
 object Constants {
-	const val VERSION_STRING = "v0.0.18"
+	const val VERSION_STRING = "v0.0.19"
 
 	// TODO: these will all be parameterised
 	val SOURCE_DIR = "sources"
@@ -69,5 +69,14 @@ object Constants {
 
 	""".trimIndent()
 
-	val logos = arrayOf(basculeLogo, logo2, logo5)
+	val logo3 = """
+.______        ___           _______.  ______  __    __   __       _______ 
+|   _  \      /   \         /       | /      ||  |  |  | |  |     |   ____|
+|  |_)  |    /  ^  \       |   (----`|  ,----'|  |  |  | |  |     |  |__   
+|   _  <    /  /_\  \       \   \    |  |     |  |  |  | |  |     |   __|  
+|  |_)  |  /  _____  \  .----)   |   |  `----.|  `--'  | |  `----.|  |____ 
+|______/  /__/     \__\ |_______/     \______| \______/  |_______||_______| $VERSION_STRING
+	""".trimIndent()
+
+	val logos = arrayOf(basculeLogo, logo2, logo5, logo3)
 }

--- a/src/main/kotlin/org/liamjd/bascule/assets/AssetsProcessor.kt
+++ b/src/main/kotlin/org/liamjd/bascule/assets/AssetsProcessor.kt
@@ -29,8 +29,8 @@ class AssetsProcessor(val project: Project) : KoinComponent {
 		copyDirectory(project.dirs.assets, destinationDir)
 	}
 
-	private fun copyFile(idx: Int, file: File, destinationDir: String) {
-		val res = fileHandler.copyFile(file, File(destinationDir + pathSeparator + file.name))
+	private fun copyFile(file: File, destinationDir: String) {
+		fileHandler.copyFile(file, File(destinationDir + pathSeparator + file.name))
 	}
 
 	private fun copyDirectory(dir: File, destination: String) {
@@ -43,7 +43,7 @@ class AssetsProcessor(val project: Project) : KoinComponent {
 				copyDirectory(file, destination + pathSeparator + file.name)
 			} else {
 				copyDirProgress.progress(idx,"Copying ${file.name} to $destination")
-				copyFile(idx, file, destination)
+				copyFile(file, destination)
 			}
 		}
 		copyDirProgress.clear()

--- a/src/main/kotlin/org/liamjd/bascule/cache/BasculeCache.kt
+++ b/src/main/kotlin/org/liamjd/bascule/cache/BasculeCache.kt
@@ -1,6 +1,8 @@
 package org.liamjd.bascule.cache
 
+import kotlinx.serialization.Serializable
 import org.liamjd.bascule.model.BasculePost
+import java.time.LocalDateTime
 
 // TODO: move to the library
 /**
@@ -8,6 +10,7 @@ import org.liamjd.bascule.model.BasculePost
  */
 interface BasculeCache {
 
+	// TODO: extend this cache to include basic information about the markdown templates
 	/**
 	 * Write a set of [MDCacheItem] to a cache file
 	 */
@@ -17,6 +20,11 @@ interface BasculeCache {
 	 * Load from the cache file into a set of [MDCacheItem]
 	 */
 	fun loadCacheFile(): Set<MDCacheItem>
+
+	/**
+	 * Load the handlebars template information, so we know if we need to trigger a clean generation regardless
+	 */
+	fun loadTemplates(): Set<HandlebarsTemplateCacheItem>
 
 }
 

--- a/src/main/kotlin/org/liamjd/bascule/cache/BasculeCacheImpl.kt
+++ b/src/main/kotlin/org/liamjd/bascule/cache/BasculeCacheImpl.kt
@@ -15,6 +15,7 @@ import java.io.FileNotFoundException
 import java.time.Instant
 import java.time.LocalDateTime
 import java.util.*
+import java.util.Collections.emptySet
 
 /**
  * Using kotlinx.serialization to serialize the cache items

--- a/src/main/kotlin/org/liamjd/bascule/cache/BasculeCacheImpl.kt
+++ b/src/main/kotlin/org/liamjd/bascule/cache/BasculeCacheImpl.kt
@@ -2,13 +2,19 @@
 
 package org.liamjd.bascule.cache
 
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonConfiguration
 import kotlinx.serialization.set
 import org.liamjd.bascule.lib.FileHandler
 import org.liamjd.bascule.lib.model.Project
 import org.liamjd.bascule.slug
+import java.io.File
+import java.io.FileFilter
 import java.io.FileNotFoundException
+import java.time.Instant
+import java.time.LocalDateTime
+import java.util.*
 
 /**
  * Using kotlinx.serialization to serialize the cache items
@@ -17,17 +23,38 @@ import java.io.FileNotFoundException
 class BasculeCacheImpl(val project: Project, val fileHandler: FileHandler) : BasculeCache {
 
 	override fun writeCacheFile(mdCacheItems: Set<MDCacheItem>) {
+
+		val cache = Cache(getTemplates(project.dirs.templates),mdCacheItems)
 		val json = Json(JsonConfiguration(prettyPrint = true))
-		val jsonData = json.stringify(MDCacheItem.serializer().set, mdCacheItems)
-		fileHandler.writeFile(project.dirs.sources, getCacheFileName(), jsonData)
+		val cacheJsonData = json.stringify(Cache.serializer(),cache)
+
+		fileHandler.writeFile(project.dirs.sources,getCacheFileName(),cacheJsonData)
+
+//		val templateJsonData = json.stringify(HandlebarsTemplateCacheItem.serializer().set,getTemplates())
+//
+//		println(templateJsonData)
+//		val jsonData = json.stringify(MDCacheItem.serializer().set, mdCacheItems)
+//		fileHandler.writeFile(project.dirs.sources, getCacheFileName(), jsonData)
 	}
 
 	override fun loadCacheFile(): Set<MDCacheItem> {
 		try {
 			val jsonString = fileHandler.readFileAsString(project.dirs.sources, getCacheFileName())
 			val json = Json(JsonConfiguration(prettyPrint = true))
-			val cacheItems: Set<MDCacheItem> = json.parse(MDCacheItem.serializer().set, jsonString)
+			val cache = json.parse(Cache.serializer(),jsonString)
+			val cacheItems: Set<MDCacheItem> = cache.items
 			return cacheItems
+		} catch (fnfe: FileNotFoundException) {
+			return emptySet()
+		}
+	}
+
+	override fun loadTemplates(): Set<HandlebarsTemplateCacheItem> {
+		try {
+			val jsonString = fileHandler.readFileAsString(project.dirs.sources, getCacheFileName())
+			val json = Json(JsonConfiguration(prettyPrint = true))
+			val cache = json.parse(Cache.serializer(),jsonString)
+			return cache.layouts
 		} catch (fnfe: FileNotFoundException) {
 			return emptySet()
 		}
@@ -36,4 +63,27 @@ class BasculeCacheImpl(val project: Project, val fileHandler: FileHandler) : Bas
 	private fun getCacheFileName(): String {
 		return "${project.name.slug()}.cache.json"
 	}
+
+	/**
+	 * Read the existing templates from file and create HandlebarsTemplateCacheItem cache items for each of them
+	 */
+	// TODO: move to interface
+	fun getTemplates(templateDir: File): Set<HandlebarsTemplateCacheItem> {
+		val templateSet = mutableSetOf<HandlebarsTemplateCacheItem>()
+		val templates = templateDir.listFiles(FileFilter { it.extension.toLowerCase() == "hbs" })
+		if(templates != null) {
+			templates.forEach { file ->
+				println("Loading template details for ${file.name}")
+				val hbCacheItem = HandlebarsTemplateCacheItem(file.name.substringBeforeLast("."), file.absolutePath, file.length(), LocalDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), TimeZone
+						.getDefault().toZoneId()))
+				templateSet.add(hbCacheItem)
+			}
+		}
+		return templateSet
+	}
+
+
 }
+
+@Serializable
+class Cache(val layouts: Set<HandlebarsTemplateCacheItem>, val items: Set<MDCacheItem>)

--- a/src/main/kotlin/org/liamjd/bascule/cache/LocalDateTimeSerializer.kt
+++ b/src/main/kotlin/org/liamjd/bascule/cache/LocalDateTimeSerializer.kt
@@ -5,6 +5,9 @@ import kotlinx.serialization.internal.StringDescriptor
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
+/**
+ * This serializer only works to ISO_DATE_TIME; nanoseconds are lost?
+ */
 @Serializer(forClass = LocalDateTime::class)
 object LocalDateTimeSerializer: KSerializer<LocalDateTime> {
 	override val descriptor: SerialDescriptor =

--- a/src/main/kotlin/org/liamjd/bascule/cache/MDCacheItem.kt
+++ b/src/main/kotlin/org/liamjd/bascule/cache/MDCacheItem.kt
@@ -47,3 +47,9 @@ class MDCacheItem(val sourceFileSize: Long, val sourceFilePath: String, @Seriali
 	}
 
 }
+
+/**
+* Simple class to represent a handlebars template cache item
+*/
+@Serializable
+class HandlebarsTemplateCacheItem(val layoutName: String, val layoutFilePath: String, val layoutFileSize: Long, @Serializable(with = LocalDateTimeSerializer::class) val layoutModificationDate: LocalDateTime)

--- a/src/main/kotlin/org/liamjd/bascule/generator/Generator.kt
+++ b/src/main/kotlin/org/liamjd/bascule/generator/Generator.kt
@@ -238,7 +238,7 @@ private fun List<Post>.process(pipeline: ArrayList<KClass<GeneratorPipeline>>, p
 						clazz.key as KClass<out GeneratorPipeline>,
 						project,
 						this@process
-				), project, renderer, fileHandler)
+				), project, renderer, fileHandler, project.clean)
 			}
 		}
 	}

--- a/src/main/kotlin/org/liamjd/bascule/pipeline/IndexPageGenerator.kt
+++ b/src/main/kotlin/org/liamjd/bascule/pipeline/IndexPageGenerator.kt
@@ -22,7 +22,7 @@ class IndexPageGenerator(posts: List<Post>, numPosts: Int = 1, postsPerPage: Int
 	private val POST_TEMPLATE = "post"
 	override val TEMPLATE: String = "index"
 
-	override suspend fun process(project: Project, renderer: TemplatePageRenderer, fileHandler: FileHandler) {
+	override suspend fun process(project: Project, renderer: TemplatePageRenderer, fileHandler: FileHandler, clean: Boolean) {
 		info("Building index file")
 
 		val model = mutableMapOf<String, Any>()

--- a/src/main/kotlin/org/liamjd/bascule/pipeline/PostNavigationGenerator.kt
+++ b/src/main/kotlin/org/liamjd/bascule/pipeline/PostNavigationGenerator.kt
@@ -14,9 +14,13 @@ class PostNavigationGenerator(posts: List<Post>, numPosts: Int = 1, postsPerPage
 	override val TEMPLATE: String = "list"
 	val FOLDER_NAME: String = "posts"		// TODO: move this to project model
 
+	// TODO: extend this interface to take an optional filter predicate
+	// TODO: extend this interface to specify the sorting order
 	override suspend fun process(project: Project, renderer: TemplatePageRenderer, fileHandler: FileHandler) {
 		val totalPages = ceil(numPosts.toDouble() / postsPerPage).roundToInt()
 		val listPages = posts.reversed().withIndex()
+				.filter { indexedValue: IndexedValue<Post> -> indexedValue.value.layout.equals("post") }
+				.sortedByDescending { it.value.date }
 				.groupBy { it.index / postsPerPage }
 				.map { it.value.map { it.value } }
 

--- a/src/main/kotlin/org/liamjd/bascule/pipeline/PostNavigationGenerator.kt
+++ b/src/main/kotlin/org/liamjd/bascule/pipeline/PostNavigationGenerator.kt
@@ -16,7 +16,7 @@ class PostNavigationGenerator(posts: List<Post>, numPosts: Int = 1, postsPerPage
 
 	// TODO: extend this interface to take an optional filter predicate
 	// TODO: extend this interface to specify the sorting order
-	override suspend fun process(project: Project, renderer: TemplatePageRenderer, fileHandler: FileHandler) {
+	override suspend fun process(project: Project, renderer: TemplatePageRenderer, fileHandler: FileHandler, clean: Boolean) {
 		val totalPages = ceil(numPosts.toDouble() / postsPerPage).roundToInt()
 		val listPages = posts.reversed().withIndex()
 				.filter { indexedValue: IndexedValue<Post> -> indexedValue.value.layout.equals("post") }

--- a/src/main/kotlin/org/liamjd/bascule/pipeline/TaxonomyNavigationGenerator.kt
+++ b/src/main/kotlin/org/liamjd/bascule/pipeline/TaxonomyNavigationGenerator.kt
@@ -20,7 +20,7 @@ class TaxonomyNavigationGenerator(posts: List<BasculePost>, numPosts: Int = 1, p
 	val FOLDER_NAME = "tags"
 	override val TEMPLATE = "tag"
 
-	override suspend fun process(project: Project, renderer: TemplatePageRenderer, fileHandler: FileHandler) {
+	override suspend fun process(project: Project, renderer: TemplatePageRenderer, fileHandler: FileHandler, clean: Boolean) {
 		info("Building tag navigation pages")
 
 		val tagsFolder = fileHandler.createDirectory(project.dirs.output.absolutePath, FOLDER_NAME)

--- a/src/main/kotlin/org/liamjd/bascule/pipeline/TaxonomyNavigationGenerator.kt
+++ b/src/main/kotlin/org/liamjd/bascule/pipeline/TaxonomyNavigationGenerator.kt
@@ -24,10 +24,14 @@ class TaxonomyNavigationGenerator(posts: List<BasculePost>, numPosts: Int = 1, p
 		info("Building tag navigation pages")
 
 		val tagsFolder = fileHandler.createDirectory(project.dirs.output.absolutePath, FOLDER_NAME)
-		val tagSet = getAllTagsFromPosts(posts)
+
+		// filter out unwanted items
+		val filteredPosts = posts.filter { it.layout.equals("post") }.sortedByDescending { it.date }
+
+		val tagSet = getAllTagsFromPosts(filteredPosts)
 
 		tagSet.forEach { tag ->
-			val taggedPosts = getPostsWithTag(posts, tag)
+			val taggedPosts = getPostsWithTag(filteredPosts, tag)
 			val numPosts = tag.postCount
 			if(numPosts != taggedPosts.size) {
 				logger.error("${tag} has a mismatch between tag.postCount (${tag.postCount}) and the count of posts with that tag (${taggedPosts.size})")

--- a/src/main/kotlin/org/liamjd/bascule/scanner/MarkdownScanner.kt
+++ b/src/main/kotlin/org/liamjd/bascule/scanner/MarkdownScanner.kt
@@ -39,9 +39,10 @@ class MarkdownScanner(val project: Project) : KoinComponent {
 
 		// this is everything we know from the cache. it might even be empty!
 		val cachedSet = cache.loadCacheFile()
+		val templateSet = cache.loadTemplates()
 
 		// if there are no changes, this set could be empty - but if the cachedSet is empty, this must be full
-		val uncachedSet = changeSetCalculator.calculateUncachedSet(cachedSet)
+		val uncachedSet = changeSetCalculator.calculateUncachedSet(cachedSet, templateSet)
 		logger.debug { "Uncached set size: ${uncachedSet.size}" }
 		val sorted = orderPosts(uncachedSet)
 		logger.debug { "Sorted uncached set size: ${sorted.size}" }

--- a/src/main/kotlin/println/println.kt
+++ b/src/main/kotlin/println/println.kt
@@ -18,6 +18,9 @@ fun error(string: String) {
 	println(Ansi.ansi().fgBrightRed().a("ERROR: $string").reset())
 }
 
+/**
+ * Prints text in a cyan colour
+ */
 fun debug(string: String) {
 	if (debug) {
 		println(Ansi.ansi().fgCyan().a("DEBUG: $string").reset())

--- a/src/main/resources/initailizer/themes/bulma/templates/index.hbs
+++ b/src/main/resources/initailizer/themes/bulma/templates/index.hbs
@@ -1,25 +1,33 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>{{ site.siteName }}</title>
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.1/css/bulma.min.css">
-	<script defer src="https://use.fontawesome.com/releases/v5.1.0/js/all.js"></script>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ siteName }}</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.1/css/bulma.min.css">
+    <script defer src="https://use.fontawesome.com/releases/v5.1.0/js/all.js"></script>
 </head>
 <body>
 <section class="section">
-	<div class="container">
-		<h1 class="title">
-			{{ site.siteName }}
-		</h1>
+    <div class="container">
+        <h1 class="title">
+            {{ siteName }}
+        </h1>
 
-		<div class="content">
-			{{#each site.basculePosts }}
-				{{ this }}
-			{{/each}}
-		</div>
-	</div>
+    <div class="content">
+        <!-- START ARTICLES -->
+        {{#forEach posts "2"}}
+            <h2 class="title article-title">{{this.title}}</h2>
+            <div class="tags has-addons">
+                <span class="tag is-rounded is-info">{{this.author}}</span>
+                <span class="tag is-rounded"><time datetime="{{localDate this.date "ISO_LOCAL_DATE"}}"> {{ localDate this.date }}</time></span>
+            </div>
+            <div class="content article-body">
+                {{{ this.content }}}
+            </div>
+        </div>
+        {{/forEach}}
+    </div>
 </section>
 </body>
 </html>

--- a/src/main/resources/initailizer/themes/bulma/templates/index.hbs
+++ b/src/main/resources/initailizer/themes/bulma/templates/index.hbs
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ siteName }}</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.1/css/bulma.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.8.0/css/bulma.min.css">
     <script defer src="https://use.fontawesome.com/releases/v5.1.0/js/all.js"></script>
 </head>
 <body>

--- a/src/main/resources/initailizer/themes/bulma/templates/list.hbs
+++ b/src/main/resources/initailizer/themes/bulma/templates/list.hbs
@@ -8,12 +8,10 @@
 	<meta name="author" content="{{author}}">
 	<meta name="generator" content="bascule">
 	<title>{{title }} - {{ siteName }}</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.1/css/bulma.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.8.0/css/bulma.min.css">
     <script defer src="https://use.fontawesome.com/releases/v5.1.0/js/all.js"></script>
 </head>
-
 <body>
-
 <section class="hero">
 	<div class="hero-body">
 		<h1 class="title is-size-1"><span class="title-wrapper"><a href="/" title="Home">{{upper siteName }}</a></span></h1>

--- a/src/main/resources/initailizer/themes/bulma/templates/list.hbs
+++ b/src/main/resources/initailizer/themes/bulma/templates/list.hbs
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="author" content="{{author}}">
+	<meta name="generator" content="bascule">
+	<title>{{title }} - {{ siteName }}</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.1/css/bulma.min.css">
+    <script defer src="https://use.fontawesome.com/releases/v5.1.0/js/all.js"></script>
+</head>
+
+<body>
+
+<section class="hero">
+	<div class="hero-body">
+		<h1 class="title is-size-1"><span class="title-wrapper"><a href="/" title="Home">{{upper siteName }}</a></span></h1>
+	</div>
+</section>
+
+<div class="container">
+	<!-- START LIST OF POSTS -->
+	<section class="pageList">
+		<div class="columns">
+			<div class="column is-7">
+
+				<nav class="pagination" role="navigation" aria-label="pagination">
+					<a class="pagination-previous"
+						{{#if isFirst}}disabled {{else}} href="list{{previousPage}}.html"{{/if}}>Previous</a>
+					<a class="pagination-next"
+						{{#if isLast}}disabled {{else}} href="list{{nextPage}}.html" {{/if}}>Next
+						page</a>
+
+					<ul class="pagination-list">
+						{{#paginate pagination currentPage totalPages }}
+
+							{{#if @current}}
+								<li>
+									<a class="pagination-link is-current"
+									   aria-current="Page {{currentPage}}">{{currentPage}}</a>
+								</li>
+							{{/if}}
+							{{#if @page}}
+								<li>
+									<a class="pagination-link" aria-label="Goto page {{@page}}"
+									   href="list{{@page}}.html">{{@page}}</a>
+								</li>
+							{{/if}}
+							{{#if @ellipsis}}
+								<li>
+									<span class="pagination-ellipsis">&hellip;</span>
+								</li>
+							{{/if}}
+
+						{{/paginate}}
+					</ul>
+
+				</nav>
+
+				<div class="card article">
+					<div class="card-content">
+						<div class="media">
+							<div class="media-content">
+								<ul>
+									{{#forEach posts }}
+										<li>
+											<div class="level">
+												<div class="level-left">
+													<div class="level-item article-title">
+														<a href="/{{this.url}}"
+														   title="{{this.title}}">{{this.title}}</a>
+													</div>
+												</div>
+												<div class="level-right">
+													<div class="level-item">
+														<small>{{localDate this.date}}</small>
+													</div>
+												</div>
+											</div>
+										</li>
+									{{/forEach}}
+								</ul>
+								<div class="is-pulled-right">
+									<small><em>{{totalPosts}} posts</em></small>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<nav class="pagination" role="navigation" aria-label="pagination">
+
+					<a class="pagination-previous"
+						{{#if isFirst}}disabled {{else}} href="list{{previousPage}}.html"{{/if}} >Previous</a>
+					<a class="pagination-next"
+						{{#if isLast}}disabled {{else}} href="list{{nextPage}}.html" {{/if}}>Next
+						page</a>
+
+					<ul class="pagination-list">
+						{{#paginate pagination currentPage totalPages }}
+
+							{{#if @current}}
+								<li>
+									<a class="pagination-link is-current"
+									   aria-current="Page {{currentPage}}">{{currentPage}}</a>
+								</li>
+							{{/if}}
+							{{#if @page}}
+								<li>
+									<a class="pagination-link" aria-label="Goto page {{@page}}"
+									   href="list{{@page}}.html">{{@page}}</a>
+								</li>
+							{{/if}}
+							{{#if @ellipsis}}
+								<li>
+									<span class="pagination-ellipsis">&hellip;</span>
+								</li>
+							{{/if}}
+
+						{{/paginate}}
+
+					</ul>
+
+				</nav>
+
+			</div>
+
+		</div>
+	</section>
+
+</div>
+<!-- END ARTICLE FEED -->
+
+</body>
+
+</html>

--- a/src/main/resources/initailizer/themes/bulma/templates/post.hbs
+++ b/src/main/resources/initailizer/themes/bulma/templates/post.hbs
@@ -14,7 +14,16 @@
 			{{ title }}
 		</h1>
 		<p class="subtitle">
-			by {{ author }} <span class="date"> {{ date }}</span> - {{#each tags }}<span class="tag is-primary">{{ this }}</span> {{/each}}
+			by {{ author }} <span class="date"> {{ date }}</span> - {{#each tags }}
+            {{#if this.hasPosts }}
+                <span class="tag is-primary is-right"><a
+                        class="has-text-white"
+                        href="/tags/{{this.url}}/{{this.url}}1.html"
+                        title="All {{ this.postCount}} posts tagged '{{this.label}}'">{{ this.label }}</a></span>
+            {{else}}
+                <span class="tag is-primary is-right">{{ this.label }}</span>
+            {{/if}}
+        {{/each}}
 		</p>
 		<div class="content">
 			{{{ content }}}

--- a/src/main/resources/initailizer/themes/bulma/templates/post.hbs
+++ b/src/main/resources/initailizer/themes/bulma/templates/post.hbs
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>{{ title }}</title>
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.1/css/bulma.min.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.8.0/css/bulma.min.css">
 	<script defer src="https://use.fontawesome.com/releases/v5.1.0/js/all.js"></script>
 </head>
 <body>
@@ -13,6 +13,7 @@
 		<h1 class="title">
 			{{ title }}
 		</h1>
+
 		<p class="subtitle">
 			by {{ author }} <span class="date"> {{ date }}</span> - {{#each tags }}
             {{#if this.hasPosts }}

--- a/src/main/resources/initailizer/themes/bulma/templates/taglist.hbs
+++ b/src/main/resources/initailizer/themes/bulma/templates/taglist.hbs
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="author" content="{{author}}">
+	<meta name="generator" content="bascule">
+	<title>{{title }} - {{ siteName }}</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.1/css/bulma.min.css">
+    <script defer src="https://use.fontawesome.com/releases/v5.1.0/js/all.js"></script>
+</head>
+
+<body>
+
+<section class="hero">
+	<div class="hero-body">
+		<h1 class="title is-size-1"><span class="title-wrapper"><a href="/" title="Home">{{upper siteName }}</a></span></h1>
+	</div>
+</section>
+
+<div class="container">
+	<!-- START LIST OF POSTS -->
+	<section class="pageList">
+		<div class="columns">
+			<div class="column is-7">
+
+				<div class="card article">
+					<div class="card-header">
+						<div class="card-header-title">
+							All tags
+						</div>
+					</div>
+					<div class="card-content">
+						<div class="media">
+							<div class="media-content">
+								<ul>
+									{{#forEach tags }}
+										<li>
+											<div class="level">
+												<div class="level-left">
+													<div class="level-item article-title">
+													<span class="tag is-primary is-right"><a
+															class="has-text-white"
+															href="../tags/{{this.url}}/{{this.url}}1.html"
+															title="All {{ this.postCount}} posts tagged '{{this.label}}'">{{ this.label }}</a></span>
+
+													</div>
+												</div>
+												<div class="level-right">
+													<div class="level-item">
+														<small>{{this.postCount}}</small>
+													</div>
+												</div>
+											</div>
+										</li>
+									{{/forEach}}
+								</ul>
+								<div class="is-pulled-right">
+									<small><em>{{tags.size}} tags</em></small>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+
+
+			</div>
+
+		</div>
+	</section>
+
+</div>
+<!-- END ARTICLE FEED -->
+
+</body>
+
+</html>

--- a/src/main/resources/initailizer/themes/bulma/templates/taglist.hbs
+++ b/src/main/resources/initailizer/themes/bulma/templates/taglist.hbs
@@ -8,12 +8,10 @@
 	<meta name="author" content="{{author}}">
 	<meta name="generator" content="bascule">
 	<title>{{title }} - {{ siteName }}</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.1/css/bulma.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.8.0/css/bulma.min.css">
     <script defer src="https://use.fontawesome.com/releases/v5.1.0/js/all.js"></script>
 </head>
-
 <body>
-
 <section class="hero">
 	<div class="hero-body">
 		<h1 class="title is-size-1"><span class="title-wrapper"><a href="/" title="Home">{{upper siteName }}</a></span></h1>

--- a/src/test/kotlin/org/liamjd/bascule/scanner/TEST_DATA.kt
+++ b/src/test/kotlin/org/liamjd/bascule/scanner/TEST_DATA.kt
@@ -1,11 +1,16 @@
 package org.liamjd.bascule.scanner
 
+import org.liamjd.bascule.cache.HandlebarsTemplateCacheItem
 import org.liamjd.bascule.cache.MDCacheItem
 import java.io.File
-import java.time.LocalDate
-import java.time.Month
+import java.time.*
+import java.time.temporal.TemporalUnit
+
 
 object TEST_DATA {
+	val post_template_modification_date = LocalDateTime.of(2019,Month.NOVEMBER,28,16,50,0)
+	val post_template_modification_date_MILLIS = post_template_modification_date.toInstant(ZoneId.systemDefault().rules.getOffset(LocalDateTime.now())).toEpochMilli()
+
 	val sources_absolute_path: String = "test/sources/path"
 	val test_project_name = "test-project"
 
@@ -13,8 +18,17 @@ object TEST_DATA {
 	val big_bang_url = "2005/review-of-big-bang.html"
 	val big_bang_date = LocalDate.of(2005, Month.OCTOBER, 8)
 	val big_bang_json = """
-	[
-		{
+	{
+		"layouts": [
+			{
+				"layoutName": "post",
+				"layoutFilePath": "D:\\Development\\liamjdavison\\liamjd-theme\\templates\\post.hbs",
+				"layoutFileSize": 3464,
+				"layoutModificationDate": "2019-11-24T10:25:10.335"
+			}
+		],
+		"items": [
+			{
 			"sourceFileSize": 1061,
 			"sourceFilePath": "D:\\Development\\liamjdavison\\sources\\2005\\Review of Big Bang.md",
 			"sourceModificationDate": "2018-09-11T21:32:30.342",
@@ -34,13 +48,17 @@ object TEST_DATA {
 			"layout": "post",
 			"rerender": true
 		}
-	]
+		]
+	}
 	""".trimIndent()
 
 	val bigBangItem = MDCacheItem(12345L, big_bang_url, big_bang_date.atStartOfDay())
 
 	val mdCacheItemSet = setOf(bigBangItem)
 	val mdCacheItemEmptySet = emptySet<MDCacheItem>()
+
+	val hbTemplateCacheEmptySet = emptySet<HandlebarsTemplateCacheItem>()
+	val hbTemplatePostItem = HandlebarsTemplateCacheItem("post","D:\\post.hbs",234L, post_template_modification_date)
 
 	val singleFileList = arrayOf<File>()
 }
@@ -71,6 +89,11 @@ object REVIEW_BIG_BANG_CACHE {
     }
 	]
 	""".trimIndent()
+}
+
+fun millsToLocalDateTime(millis: Long): LocalDateTime {
+	val instant: Instant = Instant.ofEpochMilli(millis)
+	return instant.atZone(ZoneId.systemDefault()).toLocalDateTime()
 }
 
 object REVIEW_BIG_BANG {


### PR DESCRIPTION
Forces a clean build if the handlebars templates are changed.
Better handling of plugins with non-clean builds.
Less awful templates.
Create new project new works. Oops. Needs work!