### PR TITLE
22 add claude to the project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+Bascule is a Kotlin CLI static site generator (v0.4.0). It reads Markdown files with YAML front matter from a `sources/` directory, renders them to HTML via Handlebars templates, and writes output to a `site/` directory. Run as a fat JAR built with shadow.
+
+## Build & Run
+
+```bash
+# Build fat JAR
+./gradlew shadowJar
+
+# Run tests
+./gradlew test
+
+# Run a single test class
+./gradlew test --tests "org.liamjd.bascule.model.BasculePostTest"
+
+# Publish to GitHub Packages
+./gradlew publish
+```
+
+The build requires `githubUsername` and `githubToken` in `~/.gradle/gradle.properties` to resolve the private `bascule-lib` dependency from GitHub Packages (`https://maven.pkg.github.com/v79/bascule-lib`).
+
+## CLI Commands (as built JAR)
+
+```bash
+java -jar bascule.jar -n <siteName> [--theme <themeName>]   # initialise new project
+java -jar bascule.jar generate [-c] [-p <projectName>]      # generate site; -c for clean build
+java -jar bascule.jar themes                                 # list built-in themes
+```
+
+The generator must be run from inside the project folder. It looks for `<foldername>.yaml` by default (or `<projectName>.yaml` if `-p` is set).
+
+## Architecture
+
+### Entry Point & DI
+
+`main.kt` -> `Bascule` (Picocli `@Command`) -> subcommands `Generator` and `Themes`.
+
+Dependency injection is via **Koin**, configured in `koinModules.kt`. Two modules:
+- `generationModule` -- factories for `BasculeCache`, `HandlebarsRenderer`, `ChangeSetCalculator`, `PostBuilder`, `AbstractYamlFrontMatterVisitor`
+- `fileModule` -- singleton `BasculeFileHandler`
+
+### Generation Pipeline
+
+`Generator.run()` orchestrates the full build:
+
+1. Reads `<name>.yaml` -> constructs `Project` (from `bascule-lib`) with all directory paths and config
+2. Configures Flexmark with extensions (YAML front matter, tables, attributes, YouTube, custom **HydeExtension**)
+3. `MarkdownScanner.calculateRenderSet()` determines which posts need re-rendering by comparing file mtimes/sizes against a JSON cache
+4. `MarkdownToHTMLRenderer` renders each flagged post from Markdown -> HTML string stored on the `BasculePost`
+5. `ProcessPipeline.kt` (extension function `List<Post>.process(...)`) runs the generator pipeline in parallel via coroutines. Default pipeline:
+   - `IndexPageGenerator` -- writes `index.html`
+   - `PostNavigationGenerator` -- wires `newer`/`older` links
+   - `TaxonomyNavigationGenerator` -- writes per-tag pages
+
+### Key Types
+
+- **`BasculePost`** (`model/BasculePost.kt`) -- implements `Post` (from `bascule-lib`). Built from Markdown via `BasculePost.Builder.createPostFromYaml()`. Returns sealed `PostStatus`: either a valid `BasculePost` or a `PostGenError`.
+- **`MDCacheItem`** -- serialisable cache record per source file (path, size, mtime, layout, PostLink).
+- **`CacheAndPost`** -- pairs an `MDCacheItem` with its `BasculePost?` (null when loaded from cache without re-parsing).
+- **`Project`** (from `bascule-lib`) -- holds all config: directory paths, markdown options (`MutableDataSet`), model map, postsPerPage, etc.
+
+### Post YAML Front Matter
+
+Required fields: `title`, `layout`. Optional: `author`, `slug`, `date`, `tags`. Any unknown key is stored in `post.attributes`. The `PostMetaData` enum enforces these rules.
+
+### Caching
+
+`BasculeCacheImpl` serialises a `Set<MDCacheItem>` to `<projectname>.cache.json` in the sources directory using `kotlinx.serialization`. A clean build (`-c`) deletes this file. Draft files (names starting with `.` or `__`) are skipped by `ChangeSetCalculator.walkFolder()`.
+
+### Templating
+
+`HandlebarsRenderer` loads `.hbs` files from the project's templates directory. Registered helpers: `forEach`, `paginate`, `localDate`, `capitalize`, `upper`, `slugify`.
+
+### Plugins
+
+External Flexmark extensions and custom `GeneratorPipeline` implementations can be dropped as JARs into the project's `plugins/` folder. `PluginLoader` / `HandlebarPluginLoader` / `GeneratorPluginLoader` load them via `URLClassLoader`.
+
+### Hyde Extension
+
+A custom Flexmark extension (`flexmark/hyde/`) that implements transclusion -- embedding the content of another source file inline using a special block syntax.
+
+## External Dependency: bascule-lib
+
+Core interfaces (`Post`, `Project`, `GeneratorPipeline`, `AbstractPostListGenerator`, `TemplatePageRenderer`, `FileHandler`, `Theme`, `PostLink`, `Tag`) live in the separate `bascule-lib` library (also owned by v79, published to GitHub Packages). Changes to these interfaces require a new `bascule-lib` release first.
+
+## Testing Notes
+
+The app is difficult to unit test because `Project` construction requires real filesystem state and Koin DI is hard to mock in this setup. Existing tests (`BasculePostTest`, `IndexPageGeneratorTest`) exercise the model and a single pipeline stage using test resource fixtures in `src/test/resources/afternoon/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ External Flexmark extensions and custom `GeneratorPipeline` implementations can 
 
 ### Hyde Extension
 
-A custom Flexmark extension (`flexmark/hyde/`) that implements transclusion -- embedding the content of another source file inline using a special block syntax.
+A custom Flexmark extension (`flexmark/hyde/`) that implements transclusion – embedding the content of another source file inline using a special block syntax.
 
 ## External Dependency: bascule-lib
 
@@ -91,3 +91,5 @@ Core interfaces (`Post`, `Project`, `GeneratorPipeline`, `AbstractPostListGenera
 ## Testing Notes
 
 The app is difficult to unit test because `Project` construction requires real filesystem state and Koin DI is hard to mock in this setup. Existing tests (`BasculePostTest`, `IndexPageGeneratorTest`) exercise the model and a single pipeline stage using test resource fixtures in `src/test/resources/afternoon/`.
+
+The intention is to refactor the project to improve testability.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ version = "0.5.0"
 val kotlin_version = "1.9.22"
 val bascule_lib_version = "0.5.0"
 val snakeyaml_version = "2.4"
-val mockk_version = "1.12.4"
+val mockk_version = "1.13.13"
 val flexmark_version = "0.64.8"
 val slf4j_version = "1.7.26"
 val handlebars_version = "4.4.0"
@@ -88,6 +88,8 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    // Allow ByteBuddy (used by MockK to mock final classes) to operate on newer JDKs than it was built against
+    systemProperty("net.bytebuddy.experimental", "true")
 }
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,10 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "org.liamjd"
-version = "0.4.0"
+version = "0.5.0"
 
 val kotlin_version = "1.9.22"
+val bascule_lib_version = "0.5.0"
 val snakeyaml_version = "2.4"
 val mockk_version = "1.12.4"
 val flexmark_version = "0.64.8"
@@ -11,7 +12,6 @@ val slf4j_version = "1.7.26"
 val handlebars_version = "4.4.0"
 val picocli_version = "3.8.2"
 val jansi_version = "1.17.1"
-val bascule_lib_version = "0.4.0"
 val junit_version = "5.10.2"
 val koin_version = "3.5.6"
 

--- a/src/main/kotlin/org/liamjd/bascule/BasculeFileHandler.kt
+++ b/src/main/kotlin/org/liamjd/bascule/BasculeFileHandler.kt
@@ -12,10 +12,18 @@ import java.util.*
 /**
  * File handling utility for creating files and directories, extracting files from resources, etc.
  */
-class BasculeFileHandler : FileHandler {
+class BasculeFileHandler : FileHandler, FileScanner {
 
     private val logger = KotlinLogging.logger {}
     override val pathSeparator = FileSystems.getDefault().separator!!
+
+    override fun listFiles(folder: File): List<File> = folder.listFiles()?.toList() ?: emptyList()
+
+    override fun isDirectory(file: File): Boolean = file.isDirectory
+
+    override fun length(file: File): Long = file.length()
+
+    override fun lastModified(file: File): Long = file.lastModified()
 
     override fun createDirectories(path: String): Boolean {
         val folders = File(path.replace("/", pathSeparator))

--- a/src/main/kotlin/org/liamjd/bascule/FileScanner.kt
+++ b/src/main/kotlin/org/liamjd/bascule/FileScanner.kt
@@ -1,0 +1,26 @@
+package org.liamjd.bascule
+
+import java.io.File
+
+/**
+ * A narrow, local abstraction over the disk-touching filesystem operations the scanner needs:
+ * directory listing and file metadata (size / modification time / directory test).
+ *
+ * It is defined here in bascule-static (rather than added to bascule-lib's `FileHandler`) so that the
+ * change-set calculation can be unit tested with an in-memory fake, without first cutting a bascule-lib
+ * release. Path-only operations (`File.name`, `.extension`, `.parentFile`, `.absolutePath`) are pure
+ * string manipulation and deliberately stay as plain `File` calls.
+ */
+interface FileScanner {
+
+	/** The immediate children of [folder], or an empty list if it is not a readable directory. */
+	fun listFiles(folder: File): List<File>
+
+	fun isDirectory(file: File): Boolean
+
+	/** File length in bytes. */
+	fun length(file: File): Long
+
+	/** Last-modified time in epoch milliseconds. */
+	fun lastModified(file: File): Long
+}

--- a/src/main/kotlin/org/liamjd/bascule/cache/DateConversions.kt
+++ b/src/main/kotlin/org/liamjd/bascule/cache/DateConversions.kt
@@ -1,0 +1,29 @@
+package org.liamjd.bascule.cache
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+/**
+ * Centralised date <-> epoch-seconds conversions used by the cache. These were previously duplicated
+ * (with subtly different implementations) across [PostLinkSerializer] and ChangeSetCalculator.
+ */
+object DateConversions {
+
+	/** A [LocalDate] as epoch seconds at the start of its day, in the given zone (default: system zone). */
+	fun localDateToEpochSeconds(date: LocalDate, zoneId: ZoneId = ZoneId.systemDefault()): Long =
+		date.atStartOfDay(zoneId).toEpochSecond()
+
+	/** Epoch seconds back to a [LocalDate], in the given zone (default: system zone). */
+	fun epochSecondsToLocalDate(epochSeconds: Long, zoneId: ZoneId = ZoneId.systemDefault()): LocalDate =
+		Instant.ofEpochSecond(epochSeconds).atZone(zoneId).toLocalDate()
+
+	/**
+	 * A [LocalDateTime] as epoch seconds, using the system zone's offset *at the current moment*.
+	 * NOTE: this preserves the original ChangeSetCalculator behaviour; it can be off by an hour across
+	 * a DST boundary because the offset is taken from `now()` rather than from [dateTime] itself.
+	 */
+	fun localDateTimeToEpochSeconds(dateTime: LocalDateTime, zoneId: ZoneId = ZoneId.systemDefault()): Long =
+		dateTime.toEpochSecond(zoneId.rules.getOffset(LocalDateTime.now()))
+}

--- a/src/main/kotlin/org/liamjd/bascule/cache/MDCacheItem.kt
+++ b/src/main/kotlin/org/liamjd/bascule/cache/MDCacheItem.kt
@@ -48,7 +48,7 @@ class MDCacheItem(
     }
 
     override fun equals(other: Any?): Boolean {
-        return other != null && other is MDCacheItem && this.sourceFilePath == this.sourceFilePath
+        return other != null && other is MDCacheItem && other.sourceFilePath == this.sourceFilePath
     }
 
 }

--- a/src/main/kotlin/org/liamjd/bascule/cache/PostLinkSerializer.kt
+++ b/src/main/kotlin/org/liamjd/bascule/cache/PostLinkSerializer.kt
@@ -9,9 +9,7 @@ import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import org.liamjd.bascule.lib.model.PostLink
-import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneId
 
 /**
  * Used by kotlinx.serialization in order to write the [PostLink] class to a Json file.
@@ -28,7 +26,7 @@ object PostLinkSerializer : KSerializer<PostLink> {
                 CompositeDecoder.DECODE_DONE -> break@loop
                 0 -> title = dec.decodeStringElement(descriptor, i)
                 1 -> url = dec.decodeStringElement(descriptor, i)
-                2 -> date = longToLocalDate(dec.decodeLongElement(descriptor, i))
+                2 -> date = DateConversions.epochSecondsToLocalDate(dec.decodeLongElement(descriptor, i))
                 else -> throw SerializationException("Unknown index $i")
             }
         }
@@ -46,7 +44,7 @@ object PostLinkSerializer : KSerializer<PostLink> {
         val compositeOutput = encoder.beginStructure(descriptor)
         compositeOutput.encodeStringElement(descriptor, 0, value.title)
         compositeOutput.encodeStringElement(descriptor, 1, value.url)
-        compositeOutput.encodeLongElement(descriptor, 2, localDateToLong(value.date))
+        compositeOutput.encodeLongElement(descriptor, 2, DateConversions.localDateToEpochSeconds(value.date))
         compositeOutput.endStructure(descriptor)
     }
 
@@ -55,16 +53,6 @@ object PostLinkSerializer : KSerializer<PostLink> {
         element("url", descriptor = PrimitiveSerialDescriptor("url", PrimitiveKind.STRING))
         element("date", descriptor = PrimitiveSerialDescriptor("date", PrimitiveKind.LONG))
 
-    }
-
-    private fun localDateToLong(date: LocalDate): Long {
-        val zoneId = ZoneId.systemDefault() // or: ZoneId.of("Europe/Oslo");
-        return date.atStartOfDay(zoneId).toEpochSecond()
-    }
-
-    private fun longToLocalDate(longValue: Long): LocalDate {
-        val zoneId = ZoneId.systemDefault() // or: ZoneId.of("Europe/Oslo");
-        return Instant.ofEpochSecond(longValue).atZone(ZoneId.systemDefault()).toLocalDate()
     }
 
 }

--- a/src/main/kotlin/org/liamjd/bascule/generator/Generator.kt
+++ b/src/main/kotlin/org/liamjd/bascule/generator/Generator.kt
@@ -9,6 +9,7 @@ import com.vladsch.flexmark.parser.Parser
 import com.vladsch.flexmark.util.misc.Extension
 import mu.KotlinLogging
 import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
 import org.koin.core.component.inject
 import org.koin.core.parameter.parametersOf
 import org.liamjd.bascule.BasculeFileHandler
@@ -133,7 +134,7 @@ class Generator : Runnable, KoinComponent {
 //		fileHandler.emptyFolder(File(project.dirs.output, "tags"))
 //		val walker = FolderWalker(project)
 
-        val walker = MarkdownScanner(project)
+        val walker = get<MarkdownScanner> { parametersOf(project) }
 
         val pageList = walker.calculateRenderSet(!clean)
         println("walker.calculateRenderSet() has returned ${pageList.size} CacheAndPost items")

--- a/src/main/kotlin/org/liamjd/bascule/koinModules.kt
+++ b/src/main/kotlin/org/liamjd/bascule/koinModules.kt
@@ -1,6 +1,5 @@
 package org.liamjd.bascule
 
-import com.vladsch.flexmark.ext.yaml.front.matter.AbstractYamlFrontMatterVisitor
 import org.koin.core.parameter.parametersOf
 import org.koin.dsl.module
 import org.liamjd.bascule.cache.BasculeCache
@@ -18,11 +17,12 @@ import org.liamjd.bascule.scanner.PostBuilder
  * DO NOT REMOVE THE 'USELESS CASTS' - they are required for Koin to work correctly
  */
 val generationModule = module {
-	factory { AbstractYamlFrontMatterVisitor() }
 	factory { (project: Project, fileHandler: FileHandler) -> BasculeCacheImpl(project, fileHandler) as BasculeCache }
 	factory { (project: Project) -> HandlebarsRenderer(project) as TemplatePageRenderer }
 	factory { (project: Project) -> PostBuilder(project, get<BasculeFileHandler>()) }
-	factory { (project: Project) -> ChangeSetCalculator(project, get(), get { parametersOf(project) }) }
+	factory { (project: Project) ->
+		ChangeSetCalculator(project, get(), get { parametersOf(project) }, get<BasculeFileHandler>())
+	}
 	factory { (project: Project) ->
 		val fileHandler = get<BasculeFileHandler>()
 		MarkdownScanner(

--- a/src/main/kotlin/org/liamjd/bascule/koinModules.kt
+++ b/src/main/kotlin/org/liamjd/bascule/koinModules.kt
@@ -1,6 +1,7 @@
 package org.liamjd.bascule
 
 import com.vladsch.flexmark.ext.yaml.front.matter.AbstractYamlFrontMatterVisitor
+import org.koin.core.parameter.parametersOf
 import org.koin.dsl.module
 import org.liamjd.bascule.cache.BasculeCache
 import org.liamjd.bascule.cache.BasculeCacheImpl
@@ -9,6 +10,7 @@ import org.liamjd.bascule.lib.model.Project
 import org.liamjd.bascule.lib.render.TemplatePageRenderer
 import org.liamjd.bascule.render.HandlebarsRenderer
 import org.liamjd.bascule.scanner.ChangeSetCalculator
+import org.liamjd.bascule.scanner.MarkdownScanner
 import org.liamjd.bascule.scanner.PostBuilder
 
 /**
@@ -19,8 +21,16 @@ val generationModule = module {
 	factory { AbstractYamlFrontMatterVisitor() }
 	factory { (project: Project, fileHandler: FileHandler) -> BasculeCacheImpl(project, fileHandler) as BasculeCache }
 	factory { (project: Project) -> HandlebarsRenderer(project) as TemplatePageRenderer }
-	factory { (project: Project) -> ChangeSetCalculator(project) }
-	factory { (project: Project) -> PostBuilder(project) }
+	factory { (project: Project) -> PostBuilder(project, get<BasculeFileHandler>()) }
+	factory { (project: Project) -> ChangeSetCalculator(project, get(), get { parametersOf(project) }) }
+	factory { (project: Project) ->
+		val fileHandler = get<BasculeFileHandler>()
+		MarkdownScanner(
+			project,
+			get { parametersOf(project, fileHandler) },
+			get { parametersOf(project) }
+		)
+	}
 }
 
 val fileModule = module {

--- a/src/main/kotlin/org/liamjd/bascule/model/BasculePost.kt
+++ b/src/main/kotlin/org/liamjd/bascule/model/BasculePost.kt
@@ -2,8 +2,6 @@ package org.liamjd.bascule.model
 
 import com.vladsch.flexmark.ext.yaml.front.matter.AbstractYamlFrontMatterVisitor
 import com.vladsch.flexmark.util.ast.Document
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import org.liamjd.bascule.lib.model.Post
 import org.liamjd.bascule.lib.model.PostLink
 import org.liamjd.bascule.lib.model.Project
@@ -73,7 +71,7 @@ class BasculePost(val document: Document) : Post, PostStatus() {
      * Returns a PostStatus.BasculePost if successful, or PostStatus.PostGenError if unable to parse the content.
      *
      */
-    companion object Builder : KoinComponent, Comparator<BasculePost> {
+    companion object Builder : Comparator<BasculePost> {
 
         /**
          * Sorting comparator by date order
@@ -86,8 +84,12 @@ class BasculePost(val document: Document) : Post, PostStatus() {
             }
         }
 
-        fun createPostFromYaml(file: File, document: Document, project: Project): PostStatus {
-            val yamlVisitor by inject<AbstractYamlFrontMatterVisitor>()
+        fun createPostFromYaml(
+            file: File,
+            document: Document,
+            project: Project,
+            yamlVisitor: AbstractYamlFrontMatterVisitor
+        ): PostStatus {
             yamlVisitor.visit(document)
             val data = yamlVisitor.data
 

--- a/src/main/kotlin/org/liamjd/bascule/pipeline/IndexPageGenerator.kt
+++ b/src/main/kotlin/org/liamjd/bascule/pipeline/IndexPageGenerator.kt
@@ -31,7 +31,7 @@ class IndexPageGenerator(posts: List<Post>, numPosts: Int = 1, postsPerPage: Int
 		// TODO: this is assuming that no more than `postsPerPage` posts will appear on the homepage; should really be configurable
 		val postsToRender = posts.filter { post -> post.layout == POST_TEMPLATE }.sortedByDescending { it.date }.take(postsPerPage)
 
-		val postBuilder = PostBuilder(project)
+		val postBuilder = PostBuilder(project, fileHandler)
 
 		for(p in postsToRender) {
 			if(p.rawContent.isEmpty()) {

--- a/src/main/kotlin/org/liamjd/bascule/scanner/ChangeSetCalculator.kt
+++ b/src/main/kotlin/org/liamjd/bascule/scanner/ChangeSetCalculator.kt
@@ -2,6 +2,7 @@ package org.liamjd.bascule.scanner
 
 import mu.KotlinLogging
 import org.liamjd.bascule.BasculeFileHandler
+import org.liamjd.bascule.FileScanner
 import org.liamjd.bascule.cache.CacheAndPost
 import org.liamjd.bascule.cache.DateConversions
 import org.liamjd.bascule.cache.HandlebarsTemplateCacheItem
@@ -12,10 +13,8 @@ import org.liamjd.bascule.lib.model.Tag
 import org.liamjd.bascule.model.BasculePost
 import org.liamjd.bascule.model.PostGenError
 import println.ProgressBar
-import println.debug
 import println.info
 import java.io.File
-import java.io.FileFilter
 import java.time.Instant
 import java.time.LocalDateTime
 import java.util.*
@@ -33,7 +32,8 @@ import kotlin.system.measureTimeMillis
 class ChangeSetCalculator(
     val project: Project,
     private val fileHandler: BasculeFileHandler,
-    private val postBuilder: PostBuilder
+    private val postBuilder: PostBuilder,
+    private val fileScanner: FileScanner
 ) {
 
     private val logger = KotlinLogging.logger {}
@@ -129,14 +129,14 @@ class ChangeSetCalculator(
     ): Int {
         var index = 0
         var markdownSourceCount1 = markdownSourceCount
-        fileLoop@ for (mdFile in folder.listFiles()) {
+        fileLoop@ for (mdFile in fileScanner.listFiles(folder)) {
             index++
             // walker starts with the current directory, which we don't need
             if (mdFile.absolutePath.equals(project.dirs.sources.absolutePath)) {
                 continue
             }
 
-            if (mdFile.isDirectory) {
+            if (fileScanner.isDirectory(mdFile)) {
                 walkFolder(
                     mdFile,
                     markdownScannerProgressBar,
@@ -176,12 +176,12 @@ class ChangeSetCalculator(
                 logger.debug { "Processing file ${index} ${mdFile.name}..." }
 
                 // construct MDCacheItem for this file, and compare it with the cache file
-                val fileLastModifiedDateTimeLong = mdFile.lastModified();
+                val fileLastModifiedDateTimeLong = fileScanner.lastModified(mdFile);
                 val fileLastModifiedDateTime = LocalDateTime.ofInstant(
                     Instant.ofEpochMilli(fileLastModifiedDateTimeLong), TimeZone
                         .getDefault().toZoneId()
                 )
-                val mdItem = MDCacheItem(mdFile.length(), mdFile.absolutePath, fileLastModifiedDateTime)
+                val mdItem = MDCacheItem(fileScanner.length(mdFile), mdFile.absolutePath, fileLastModifiedDateTime)
 
 
                 // check for errors
@@ -198,7 +198,7 @@ class ChangeSetCalculator(
                                 val htTemplateFile: File = getTemplate(project.dirs.templates, post.layout)
                                 val templateCacheItem = layoutSet.find { it.layoutName == post.layout }
                                 if (templateCacheItem != null) {
-                                    if (DateConversions.localDateTimeToEpochSeconds(templateCacheItem.layoutModificationDate) != htTemplateFile.lastModified() / 1000) {
+                                    if (DateConversions.localDateTimeToEpochSeconds(templateCacheItem.layoutModificationDate) != fileScanner.lastModified(htTemplateFile) / 1000) {
                                         info("Template '${post.layout}' has been modified; this post needs regenerated even though markdown source has not been changed since last generation.")
                                         // should fall to end of if statements now
                                     } else {
@@ -248,28 +248,6 @@ class ChangeSetCalculator(
         return markdownSourceCount1
     }
 
-
-    /**
-     * Read the existing templates from file and create HandlebarsTemplateCacheItem cache items for each of them
-     */
-    // TODO: move to interface
-    fun getTemplates(templateDir: File): Set<HandlebarsTemplateCacheItem> {
-        val templateSet = mutableSetOf<HandlebarsTemplateCacheItem>()
-        val templates = templateDir.listFiles(FileFilter { it.extension.lowercase(Locale.getDefault()) == "hbs" })
-        if (templates != null) {
-            templates.forEach { file ->
-                debug("Loading template details for ${file.name}")
-                val hbCacheItem = HandlebarsTemplateCacheItem(
-                    file.name.substringBeforeLast("."), file.absolutePath, file.length(), LocalDateTime.ofInstant(
-                        Instant.ofEpochMilli(file.lastModified()), TimeZone
-                            .getDefault().toZoneId()
-                    )
-                )
-                templateSet.add(hbCacheItem)
-            }
-        }
-        return templateSet
-    }
 
     // TODO: move to interface
     /**

--- a/src/main/kotlin/org/liamjd/bascule/scanner/ChangeSetCalculator.kt
+++ b/src/main/kotlin/org/liamjd/bascule/scanner/ChangeSetCalculator.kt
@@ -6,6 +6,7 @@ import org.koin.core.component.inject
 import org.koin.core.parameter.parametersOf
 import org.liamjd.bascule.BasculeFileHandler
 import org.liamjd.bascule.cache.CacheAndPost
+import org.liamjd.bascule.cache.DateConversions
 import org.liamjd.bascule.cache.HandlebarsTemplateCacheItem
 import org.liamjd.bascule.cache.MDCacheItem
 import org.liamjd.bascule.lib.model.PostLink
@@ -149,19 +150,19 @@ class ChangeSetCalculator(val project: Project) : KoinComponent {
                 )
             }
 
-            if (mdFile.parentFile.name.startsWith(".") || mdFile.parentFile.name.startsWith("__")) {
+            if (isDraftName(mdFile.parentFile.name)) {
                 logger.warn { "Skipping file ${mdFile.name} in draft folder '${mdFile.parentFile.name}' " }
                 continue // skip this one
             }
 
-            if (mdFile.name.startsWith(".") || mdFile.name.startsWith("__")) {
+            if (isDraftName(mdFile.name)) {
                 markdownScannerProgressBar.progress(index, "Skipping draft file/folder '${mdFile.name}'")
                 logger.warn { "Skipping draft file '${mdFile.name}' " }
                 // TODO: this isn't skipping a directory whose name begins with "__" or "."
                 continue // skip this one
             }
 
-            if (mdFile.extension.lowercase(Locale.getDefault()) != "md") {
+            if (!isMarkdownFile(mdFile)) {
                 logger.warn { "Skipping file ${mdFile.name} as extension does not match '.md'" }
                 markdownScannerProgressBar.progress(
                     markdownSourceCount1,
@@ -199,7 +200,7 @@ class ChangeSetCalculator(val project: Project) : KoinComponent {
                                 val htTemplateFile: File = getTemplate(project.dirs.templates, post.layout)
                                 val templateCacheItem = layoutSet.find { it.layoutName == post.layout }
                                 if (templateCacheItem != null) {
-                                    if (localDateTimeToLong(templateCacheItem.layoutModificationDate) != htTemplateFile.lastModified() / 1000) {
+                                    if (DateConversions.localDateTimeToEpochSeconds(templateCacheItem.layoutModificationDate) != htTemplateFile.lastModified() / 1000) {
                                         info("Template '${post.layout}' has been modified; this post needs regenerated even though markdown source has not been changed since last generation.")
                                         // should fall to end of if statements now
                                     } else {
@@ -250,31 +251,6 @@ class ChangeSetCalculator(val project: Project) : KoinComponent {
     }
 
 
-    private fun cacheContainsItem(mdItem: MDCacheItem, cachedSet: Set<MDCacheItem>): Boolean {
-        var cacheFound = false;
-
-        for (c in cachedSet) {
-            if (c.sourceFilePath.equals(mdItem.sourceFilePath) && c.sourceModificationDate.equals(mdItem.sourceModificationDate) && c.sourceFileSize.equals(
-                    mdItem.sourceFileSize
-                )
-            ) {
-                logger.info { "Cache match found for ${mdItem.sourceFilePath}" }
-                cacheFound = true
-            }
-        }
-
-        return cacheFound
-    }
-
-    private fun calculateUrl(slug: String, sourcePath: String): String {
-        val url: String = if (sourcePath.isEmpty()) {
-            "$slug.html"
-        } else {
-            "${sourcePath.removePrefix("\\")}\\$slug.html".replace("\\", "/")
-        }
-        return url
-    }
-
     /**
      * Read the existing templates from file and create HandlebarsTemplateCacheItem cache items for each of them
      */
@@ -303,11 +279,5 @@ class ChangeSetCalculator(val project: Project) : KoinComponent {
      */
 	private fun getTemplate(templateDir: File, layoutName: String): File {
         return fileHandler.getFile(templateDir, "$layoutName.hbs")
-    }
-
-    // TODO: duplicated function
-    private fun localDateTimeToLong(date: LocalDateTime): Long {
-        val zoneId = ZoneId.systemDefault() // or: ZoneId.of("Europe/Oslo");
-        return date.toEpochSecond(zoneId.rules.getOffset(LocalDateTime.now()))
     }
 }

--- a/src/main/kotlin/org/liamjd/bascule/scanner/ChangeSetCalculator.kt
+++ b/src/main/kotlin/org/liamjd/bascule/scanner/ChangeSetCalculator.kt
@@ -1,9 +1,6 @@
 package org.liamjd.bascule.scanner
 
 import mu.KotlinLogging
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
-import org.koin.core.parameter.parametersOf
 import org.liamjd.bascule.BasculeFileHandler
 import org.liamjd.bascule.cache.CacheAndPost
 import org.liamjd.bascule.cache.DateConversions
@@ -21,7 +18,6 @@ import java.io.File
 import java.io.FileFilter
 import java.time.Instant
 import java.time.LocalDateTime
-import java.time.ZoneId
 import java.util.*
 import kotlin.system.measureTimeMillis
 
@@ -34,10 +30,12 @@ import kotlin.system.measureTimeMillis
  * @param project the bascule project
  *
  */
-class ChangeSetCalculator(val project: Project) : KoinComponent {
+class ChangeSetCalculator(
+    val project: Project,
+    private val fileHandler: BasculeFileHandler,
+    private val postBuilder: PostBuilder
+) {
 
-    private val fileHandler: BasculeFileHandler by inject { parametersOf() }
-    private val postBuilder: PostBuilder by inject { parametersOf(project) }
     private val logger = KotlinLogging.logger {}
 
     /**

--- a/src/main/kotlin/org/liamjd/bascule/scanner/MarkdownScanner.kt
+++ b/src/main/kotlin/org/liamjd/bascule/scanner/MarkdownScanner.kt
@@ -78,33 +78,10 @@ class MarkdownScanner(val project: Project) : KoinComponent {
      */
     private fun orderPosts(posts: Set<CacheAndPost>): Set<CacheAndPost> {
         info("sorting")
-        val sortedSet = posts.toSortedSet(
-            compareBy(
-                { cacheAndPost -> cacheAndPost.mdCacheItem.link.date },
-                { cacheAndPost -> cacheAndPost.mdCacheItem.link.url })
-        )
+        info("building next and previous links")
+        val sortedSet = sortAndLinkPosts(posts, BLOG_POST)
         logger.info { "${sortedSet.size} markdown files sorted" }
         info("${sortedSet.size} markdown files sorted")
-        info("building next and previous links")
-
-        val filteredList =
-            sortedSet.filter { cacheAndPost -> cacheAndPost.mdCacheItem.layout.equals(BLOG_POST) }.toList()
-        filteredList.forEachIndexed { index, cacheAndPost ->
-            if (index != 0) {
-                val olderPost = filteredList[index - 1].mdCacheItem
-                cacheAndPost.mdCacheItem.previous = olderPost.link
-                cacheAndPost.post?.older = olderPost.link
-            }
-            if (index != filteredList.size - 1) {
-                val newerPost = filteredList[index + 1].mdCacheItem
-                cacheAndPost.mdCacheItem.next = newerPost.link
-                cacheAndPost.post?.newer = newerPost.link
-            }
-        }
-
-        info("Excluding non-post items leaves ${filteredList.size}")
-        logger.info { "Excluding non-post items leaves ${filteredList.size}" }
-
         return sortedSet
     }
 }

--- a/src/main/kotlin/org/liamjd/bascule/scanner/MarkdownScanner.kt
+++ b/src/main/kotlin/org/liamjd/bascule/scanner/MarkdownScanner.kt
@@ -1,10 +1,6 @@
 package org.liamjd.bascule.scanner
 
 import mu.KotlinLogging
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
-import org.koin.core.parameter.parametersOf
-import org.liamjd.bascule.BasculeFileHandler
 import org.liamjd.bascule.cache.BasculeCache
 import org.liamjd.bascule.cache.CacheAndPost
 import org.liamjd.bascule.cache.HandlebarsTemplateCacheItem
@@ -17,12 +13,13 @@ import println.info
  * @param project the bascule project
  * Call [MarkdownScanner.calculateRenderSet] to get the set of posts which need to be rerendered
  */
-class MarkdownScanner(val project: Project) : KoinComponent {
+class MarkdownScanner(
+    val project: Project,
+    private val cache: BasculeCache,
+    private val changeSetCalculator: ChangeSetCalculator
+) {
 
-    private val fileHandler: BasculeFileHandler by inject { parametersOf() }
-    private val cache: BasculeCache by inject<BasculeCache> { parametersOf(project, fileHandler) }
     private val logger = KotlinLogging.logger {}
-    private val changeSetCalculator: ChangeSetCalculator by inject { parametersOf(project) }
     private val BLOG_POST = "post"
 
     // this method is called by the Generator

--- a/src/main/kotlin/org/liamjd/bascule/scanner/PostBuilder.kt
+++ b/src/main/kotlin/org/liamjd/bascule/scanner/PostBuilder.kt
@@ -1,5 +1,6 @@
 package org.liamjd.bascule.scanner
 
+import com.vladsch.flexmark.ext.yaml.front.matter.AbstractYamlFrontMatterVisitor
 import com.vladsch.flexmark.parser.Parser
 import com.vladsch.flexmark.util.ast.Document
 import org.liamjd.bascule.lib.FileHandler
@@ -24,7 +25,8 @@ class PostBuilder(val project: Project, private val fileHandler: FileHandler) {
 	 */
 	fun buildPost(mdFile: File): PostStatus {
 		val document = parseMarkdown(mdFile)
-		val post = BasculePost.createPostFromYaml(mdFile, document, project)
+		// a fresh visitor per post; the visitor accumulates YAML data and must not be shared across files
+		val post = BasculePost.createPostFromYaml(mdFile, document, project, AbstractYamlFrontMatterVisitor())
 
 		return post
 	}

--- a/src/main/kotlin/org/liamjd/bascule/scanner/PostBuilder.kt
+++ b/src/main/kotlin/org/liamjd/bascule/scanner/PostBuilder.kt
@@ -2,10 +2,7 @@ package org.liamjd.bascule.scanner
 
 import com.vladsch.flexmark.parser.Parser
 import com.vladsch.flexmark.util.ast.Document
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
-import org.koin.core.parameter.parametersOf
-import org.liamjd.bascule.BasculeFileHandler
+import org.liamjd.bascule.lib.FileHandler
 import org.liamjd.bascule.lib.model.Project
 import org.liamjd.bascule.model.BasculePost
 import org.liamjd.bascule.model.PostStatus
@@ -16,9 +13,7 @@ import java.io.File
  * Utility class to construct a [BasculePost] from a markdown source file
  * Most of the work is delegated to the [BasculePost.createPostFromYaml] method, after first parsing the markdown document.
  */
-class PostBuilder(val project: Project) : KoinComponent {
-
-	private val fileHandler: BasculeFileHandler by inject{ parametersOf() }
+class PostBuilder(val project: Project, private val fileHandler: FileHandler) {
 
 	val mdParser: Parser = Parser.builder(project.markdownOptions).build()
 	private val cacheFileName: String = "${project.name.slug()}.cache.json"

--- a/src/main/kotlin/org/liamjd/bascule/scanner/ScannerFunctions.kt
+++ b/src/main/kotlin/org/liamjd/bascule/scanner/ScannerFunctions.kt
@@ -1,0 +1,74 @@
+package org.liamjd.bascule.scanner
+
+import org.liamjd.bascule.cache.CacheAndPost
+import org.liamjd.bascule.cache.MDCacheItem
+import java.io.File
+import java.util.Locale
+
+/**
+ * Pure, side-effect-free helpers extracted from [ChangeSetCalculator] and MarkdownScanner so that the
+ * trickiest logic (URL building, cache comparison, file filtering, post ordering) can be unit tested
+ * without a filesystem or Koin.
+ */
+
+const val MARKDOWN_EXTENSION = "md"
+
+/**
+ * A draft file or folder is one whose name starts with "." or "__". Drafts are skipped during scanning.
+ */
+fun isDraftName(name: String): Boolean = name.startsWith(".") || name.startsWith("__")
+
+/** True if the file has a (case-insensitive) `.md` extension. Pure: only inspects the path string. */
+fun isMarkdownFile(file: File): Boolean =
+	file.extension.lowercase(Locale.getDefault()) == MARKDOWN_EXTENSION
+
+/**
+ * Build the output URL for a post from its slug and the source sub-path (relative to the sources root).
+ * A leading backslash is stripped and all backslashes are normalised to forward slashes.
+ */
+fun calculateUrl(slug: String, sourcePath: String): String =
+	if (sourcePath.isEmpty()) {
+		"$slug.html"
+	} else {
+		"${sourcePath.removePrefix("\\")}\\$slug.html".replace("\\", "/")
+	}
+
+/**
+ * True if [cachedSet] already contains an item matching [mdItem] on path, modification date AND size,
+ * i.e. a genuine cache hit where the source file has not changed since the cache was written.
+ */
+fun cacheContainsItem(mdItem: MDCacheItem, cachedSet: Set<MDCacheItem>): Boolean =
+	cachedSet.any {
+		it.sourceFilePath == mdItem.sourceFilePath &&
+			it.sourceModificationDate == mdItem.sourceModificationDate &&
+			it.sourceFileSize == mdItem.sourceFileSize
+	}
+
+/**
+ * Sort [posts] by post date then url, and wire up the `previous`/`next` links (and the corresponding
+ * `older`/`newer` links on any attached post) across the subset whose layout matches [blogPostLayout].
+ * Mutates the [MDCacheItem]s (and posts) in place and returns the sorted set.
+ */
+fun sortAndLinkPosts(posts: Set<CacheAndPost>, blogPostLayout: String): Set<CacheAndPost> {
+	val sortedSet = posts.toSortedSet(
+		compareBy(
+			{ cacheAndPost -> cacheAndPost.mdCacheItem.link.date },
+			{ cacheAndPost -> cacheAndPost.mdCacheItem.link.url })
+	)
+
+	val filteredList = sortedSet.filter { it.mdCacheItem.layout == blogPostLayout }.toList()
+	filteredList.forEachIndexed { index, cacheAndPost ->
+		if (index != 0) {
+			val olderPost = filteredList[index - 1].mdCacheItem
+			cacheAndPost.mdCacheItem.previous = olderPost.link
+			cacheAndPost.post?.older = olderPost.link
+		}
+		if (index != filteredList.size - 1) {
+			val newerPost = filteredList[index + 1].mdCacheItem
+			cacheAndPost.mdCacheItem.next = newerPost.link
+			cacheAndPost.post?.newer = newerPost.link
+		}
+	}
+
+	return sortedSet
+}

--- a/src/test/kotlin/org/liamjd/bascule/FakeFileScanner.kt
+++ b/src/test/kotlin/org/liamjd/bascule/FakeFileScanner.kt
@@ -1,0 +1,38 @@
+package org.liamjd.bascule
+
+import java.io.File
+
+/**
+ * In-memory [FileScanner] test double. Model a directory tree by registering directories (with their
+ * children) and files (with size + modification time), keyed by path. Unregistered paths behave as a
+ * missing, zero-length, non-directory entry.
+ */
+class FakeFileScanner : FileScanner {
+
+	private data class Entry(
+		val isDirectory: Boolean,
+		val children: List<File> = emptyList(),
+		val length: Long = 0L,
+		val lastModified: Long = 0L
+	)
+
+	private val entries = mutableMapOf<String, Entry>()
+
+	fun addDirectory(path: File, children: List<File>): FakeFileScanner {
+		entries[path.path] = Entry(isDirectory = true, children = children)
+		return this
+	}
+
+	fun addFile(path: File, length: Long = 0L, lastModified: Long = 0L): FakeFileScanner {
+		entries[path.path] = Entry(isDirectory = false, length = length, lastModified = lastModified)
+		return this
+	}
+
+	override fun listFiles(folder: File): List<File> = entries[folder.path]?.children ?: emptyList()
+
+	override fun isDirectory(file: File): Boolean = entries[file.path]?.isDirectory ?: false
+
+	override fun length(file: File): Long = entries[file.path]?.length ?: 0L
+
+	override fun lastModified(file: File): Long = entries[file.path]?.lastModified ?: 0L
+}

--- a/src/test/kotlin/org/liamjd/bascule/FileScannerTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/FileScannerTest.kt
@@ -1,0 +1,78 @@
+package org.liamjd.bascule
+
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the real [FileScanner] implementation on [BasculeFileHandler] against an actual temp
+ * directory, and that the in-memory [FakeFileScanner] models the same contract for unit tests.
+ */
+class FileScannerTest {
+
+	private val handler = BasculeFileHandler()
+
+	// ---- real implementation, backed by a temp directory ------------------
+
+	@Test
+	fun `listFiles returns the immediate children of a directory`(@TempDir tempDir: File) {
+		File(tempDir, "a.md").writeText("hello")
+		File(tempDir, "b.md").writeText("world")
+		File(tempDir, "sub").mkdir()
+
+		val names = handler.listFiles(tempDir).map { it.name }.toSet()
+		assertEquals(setOf("a.md", "b.md", "sub"), names)
+	}
+
+	@Test
+	fun `isDirectory distinguishes directories from files`(@TempDir tempDir: File) {
+		val file = File(tempDir, "post.md").apply { writeText("x") }
+		val dir = File(tempDir, "folder").apply { mkdir() }
+
+		assertTrue(handler.isDirectory(dir))
+		assertFalse(handler.isDirectory(file))
+	}
+
+	@Test
+	fun `length reports the file size in bytes`(@TempDir tempDir: File) {
+		val file = File(tempDir, "post.md").apply { writeText("hello") } // 5 bytes
+		assertEquals(5L, handler.length(file))
+	}
+
+	@Test
+	fun `lastModified is populated for a real file`(@TempDir tempDir: File) {
+		val file = File(tempDir, "post.md").apply { writeText("x") }
+		assertTrue(handler.lastModified(file) > 0L)
+	}
+
+	@Test
+	fun `listFiles returns empty for a non-directory or missing path`(@TempDir tempDir: File) {
+		val file = File(tempDir, "post.md").apply { writeText("x") }
+		assertTrue(handler.listFiles(file).isEmpty())
+		assertTrue(handler.listFiles(File(tempDir, "does-not-exist")).isEmpty())
+	}
+
+	// ---- the fake honours the same contract -------------------------------
+
+	@Test
+	fun `FakeFileScanner models directories, children and metadata`() {
+		val root = File("/sources")
+		val postA = File("/sources/a.md")
+		val fake = FakeFileScanner()
+			.addDirectory(root, listOf(postA))
+			.addFile(postA, length = 42L, lastModified = 1000L)
+
+		assertEquals(listOf(postA), fake.listFiles(root))
+		assertTrue(fake.isDirectory(root))
+		assertFalse(fake.isDirectory(postA))
+		assertEquals(42L, fake.length(postA))
+		assertEquals(1000L, fake.lastModified(postA))
+		// unknown path: empty / non-directory / zero
+		assertTrue(fake.listFiles(File("/nowhere")).isEmpty())
+		assertFalse(fake.isDirectory(File("/nowhere")))
+		assertEquals(0L, fake.length(File("/nowhere")))
+	}
+}

--- a/src/test/kotlin/org/liamjd/bascule/SlugTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/SlugTest.kt
@@ -1,0 +1,48 @@
+package org.liamjd.bascule
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for the [String.slug] extension in Constants.kt. It lowercases the string and replaces every
+ * character outside [a-zA-Z0-9-] with a single dash.
+ */
+class SlugTest {
+
+	@Test
+	fun `lowercases the input`() {
+		assertEquals("hello", "HELLO".slug())
+	}
+
+	@Test
+	fun `replaces spaces with dashes`() {
+		assertEquals("hello-world", "Hello World".slug())
+	}
+
+	@Test
+	fun `preserves digits`() {
+		assertEquals("post-123", "Post 123".slug())
+	}
+
+	@Test
+	fun `keeps existing dashes untouched`() {
+		assertEquals("already-slugged", "already-slugged".slug())
+	}
+
+	@Test
+	fun `replaces each punctuation character with its own dash`() {
+		// "foo & bar!" -> space, &, space and ! each become a dash (no collapsing)
+		assertEquals("foo---bar-", "foo & bar!".slug())
+	}
+
+	@Test
+	fun `does NOT collapse consecutive separators`() {
+		// documented quirk: two spaces produce two dashes
+		assertEquals("a--b", "a  b".slug())
+	}
+
+	@Test
+	fun `leaves an already clean string unchanged`() {
+		assertEquals("simple", "simple".slug())
+	}
+}

--- a/src/test/kotlin/org/liamjd/bascule/cache/CacheSerializationTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/cache/CacheSerializationTest.kt
@@ -1,0 +1,54 @@
+package org.liamjd.bascule.cache
+
+import kotlinx.serialization.json.Json
+import org.liamjd.bascule.lib.model.PostLink
+import java.time.LocalDate
+import java.time.LocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Round-trip tests for the custom kotlinx.serialization serializers used by the document cache.
+ */
+class CacheSerializationTest {
+
+	@Test
+	fun `LocalDateTime survives a serialize-deserialize round trip`() {
+		val original = LocalDateTime.of(2026, 5, 31, 14, 30, 15)
+
+		val json = Json.encodeToString(LocalDateTimeSerializer, original)
+		val restored = Json.decodeFromString(LocalDateTimeSerializer, json)
+
+		assertEquals(original, restored)
+	}
+
+	@Test
+	fun `LocalDateTime is serialized as a quoted ISO string`() {
+		val original = LocalDateTime.of(2026, 5, 31, 14, 30, 15)
+
+		val json = Json.encodeToString(LocalDateTimeSerializer, original)
+
+		assertEquals("\"2026-05-31T14:30:15\"", json)
+	}
+
+	@Test
+	fun `PostLink title and url survive a serialize-deserialize round trip`() {
+		val original = PostLink("My First Post", "/my-first-post", LocalDate.of(2026, 5, 31))
+
+		val json = Json.encodeToString(PostLinkSerializer, original)
+		val restored = Json.decodeFromString(PostLinkSerializer, json)
+
+		assertEquals(original.title, restored.title)
+		assertEquals(original.url, restored.url)
+	}
+
+	@Test
+	fun `PostLink date survives a serialize-deserialize round trip`() {
+		val original = PostLink("Title", "/url", LocalDate.of(2026, 5, 31))
+
+		val json = Json.encodeToString(PostLinkSerializer, original)
+		val restored = Json.decodeFromString(PostLinkSerializer, json)
+
+		assertEquals(original.date, restored.date)
+	}
+}

--- a/src/test/kotlin/org/liamjd/bascule/cache/DateConversionsTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/cache/DateConversionsTest.kt
@@ -1,0 +1,41 @@
+package org.liamjd.bascule.cache
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DateConversionsTest {
+
+	// Use a fixed UTC zone so the assertions are independent of the machine's timezone.
+	private val utc = ZoneId.of("UTC")
+
+	@Test
+	fun `localDate round-trips through epoch seconds`() {
+		val date = LocalDate.of(2026, 5, 31)
+		val epoch = DateConversions.localDateToEpochSeconds(date, utc)
+		assertEquals(date, DateConversions.epochSecondsToLocalDate(epoch, utc))
+	}
+
+	@Test
+	fun `localDate converts to start-of-day epoch seconds in UTC`() {
+		val date = LocalDate.of(1970, 1, 2)
+		// one day after the epoch = 86400 seconds
+		assertEquals(86_400L, DateConversions.localDateToEpochSeconds(date, utc))
+	}
+
+	@Test
+	fun `epoch seconds within a day map back to that day`() {
+		// 86400 = start of 1970-01-02; add a few hours, still the same date
+		val date = DateConversions.epochSecondsToLocalDate(86_400L + 3_600L, utc)
+		assertEquals(LocalDate.of(1970, 1, 2), date)
+	}
+
+	@Test
+	fun `localDateTime converts to epoch seconds using the supplied zone`() {
+		val dateTime = LocalDateTime.of(1970, 1, 1, 1, 0, 0) // 01:00 UTC
+		assertEquals(3_600L, DateConversions.localDateTimeToEpochSeconds(dateTime, ZoneOffset.UTC))
+	}
+}

--- a/src/test/kotlin/org/liamjd/bascule/cache/MDCacheItemTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/cache/MDCacheItemTest.kt
@@ -1,0 +1,59 @@
+package org.liamjd.bascule.cache
+
+import java.time.LocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+
+/**
+ * [MDCacheItem] deliberately bases equality and hashCode on the source file path alone, so that it can
+ * be used in a [Set] keyed by file. These tests pin down that contract.
+ */
+class MDCacheItemTest {
+
+	private val modDate = LocalDateTime.of(2026, 5, 31, 12, 0, 0)
+
+	private fun item(path: String, size: Long = 100L) =
+		MDCacheItem(sourceFileSize = size, sourceFilePath = path, sourceModificationDate = modDate)
+
+	@Test
+	fun `items with the same source path are equal regardless of size`() {
+		val a = item("/sources/post.md", size = 100L)
+		val b = item("/sources/post.md", size = 999L)
+		assertEquals(a, b)
+	}
+
+	@Test
+	fun `items with different source paths are not equal`() {
+		val a = item("/sources/one.md")
+		val b = item("/sources/two.md")
+		assertNotEquals(a, b)
+	}
+
+	@Test
+	fun `hashCode is derived solely from the source path`() {
+		val a = item("/sources/post.md", size = 100L)
+		val b = item("/sources/post.md", size = 42L)
+		assertEquals(a.hashCode(), b.hashCode())
+	}
+
+	@Test
+	fun `a Set deduplicates items that share a source path`() {
+		val set = setOf(item("/sources/one.md"), item("/sources/one.md", size = 5L))
+		assertEquals(1, set.size)
+	}
+
+	@Test
+	fun `a Set keeps items with distinct source paths`() {
+		val set = setOf(item("/sources/one.md"), item("/sources/two.md"))
+		assertEquals(2, set.size)
+	}
+
+	@Test
+	fun `an item is not equal to null or to other types`() {
+		val a = item("/sources/one.md")
+		assertNotEquals<Any?>(a, null)
+		assertFalse(a.equals("/sources/one.md"))
+	}
+}

--- a/src/test/kotlin/org/liamjd/bascule/model/BasculePostTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/model/BasculePostTest.kt
@@ -9,9 +9,6 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.dsl.module
 import org.liamjd.bascule.lib.model.Project
 import java.io.File
 import kotlin.test.*
@@ -38,9 +35,6 @@ class BasculePostTest {
     """.trimIndent()
 
     private val project: Project = Project(yamlConfig = yamlConfig)
-    private val koinModule = module {
-        factory { mockYamlVisitor }
-    }
 
     private val frontispiece: MutableMap<String, List<String>> = mutableMapOf(
         "title" to listOf("Test Post"),
@@ -52,15 +46,6 @@ class BasculePostTest {
     @BeforeEach
     fun setup() {
         every { mockYamlVisitor.visit(any<Document>()) } just Runs
-
-        startKoin {
-            modules(koinModule)
-        }
-    }
-
-    @AfterTest
-    fun tearDown() {
-        stopKoin()
     }
 
     @Test
@@ -79,7 +64,7 @@ class BasculePostTest {
         every { mockYamlVisitor.data } returns frontispiece.toMap()
         // execute
         val document = parseMarkdown(markdown)
-        val post = BasculePost.createPostFromYaml(mockFile, document, project)
+        val post = BasculePost.createPostFromYaml(mockFile, document, project, mockYamlVisitor)
 
         // verify
         assertNotNull(post)
@@ -108,7 +93,7 @@ class BasculePostTest {
         every { mockYamlVisitor.data } returns emptyMap() // Simulate no YAML frontispiece
 
         // execute
-        val post = BasculePost.createPostFromYaml(mockFile, document, project)
+        val post = BasculePost.createPostFromYaml(mockFile, document, project, mockYamlVisitor)
 
         // verify
         assertNotNull(post)
@@ -131,7 +116,7 @@ class BasculePostTest {
         every { mockYamlVisitor.data } returns mapOf("layout" to listOf("post")) // Missing 'title'
 
         // execute
-        val post = BasculePost.createPostFromYaml(mockFile, document, project)
+        val post = BasculePost.createPostFromYaml(mockFile, document, project, mockYamlVisitor)
 
         // verify
         assertIs<PostGenError>(post)
@@ -152,7 +137,7 @@ class BasculePostTest {
         every { mockYamlVisitor.data } returns mapOf("title" to listOf(""), "layout" to listOf("post")) // Empty title
 
         // execute
-        val post = BasculePost.createPostFromYaml(mockFile, document, project)
+        val post = BasculePost.createPostFromYaml(mockFile, document, project, mockYamlVisitor)
 
         // verify
         assertIs<PostGenError>(post)
@@ -178,7 +163,7 @@ class BasculePostTest {
         ) // Multiple dates
 
         // execute
-        val post = BasculePost.createPostFromYaml(mockFile, document, project)
+        val post = BasculePost.createPostFromYaml(mockFile, document, project, mockYamlVisitor)
 
         // verify
         assertIs<PostGenError>(post)
@@ -208,7 +193,7 @@ class BasculePostTest {
 
         // execute
         val document = parseMarkdown(markdown)
-        val post = BasculePost.createPostFromYaml(mockFile, document, project)
+        val post = BasculePost.createPostFromYaml(mockFile, document, project, mockYamlVisitor)
 
         // verify
         assertNotNull(post)
@@ -239,7 +224,7 @@ class BasculePostTest {
 
         // execute
         val document = parseMarkdown(markdown)
-        val post = BasculePost.createPostFromYaml(mockFile, document, project)
+        val post = BasculePost.createPostFromYaml(mockFile, document, project, mockYamlVisitor)
 
         // verify
         assertNotNull(post)
@@ -264,7 +249,7 @@ class BasculePostTest {
 
         // execute
         val document = parseMarkdown(markdown)
-        val post = BasculePost.createPostFromYaml(mockFile, document, project)
+        val post = BasculePost.createPostFromYaml(mockFile, document, project, mockYamlVisitor)
 
         // verify
         assertNotNull(post)
@@ -294,7 +279,7 @@ class BasculePostTest {
 
         // execute
         val document = parseMarkdown(markdown)
-        val post = BasculePost.createPostFromYaml(mockFile, document, project)
+        val post = BasculePost.createPostFromYaml(mockFile, document, project, mockYamlVisitor)
 
         // verify
         assertNotNull(post)

--- a/src/test/kotlin/org/liamjd/bascule/pipeline/IndexPageGeneratorTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/pipeline/IndexPageGeneratorTest.kt
@@ -19,9 +19,6 @@ class IndexPageGeneratorTest {
     private val mockFileH = mockk<org.liamjd.bascule.lib.FileHandler>()
     private val mockBFH = mockk<BasculeFileHandler>()
 
-    // This value comes from the Project constructor and is based on System.getProperty("user.dir")
-    // Which I don't like
-    private var outputFile = File("C:\\Users\\liamj\\Development\\Bascule\\bascule-static\\site")
     private val yamlConfig = """
         siteName: Liam John Davison
         dateFormat: "dd/MM/yyyy"
@@ -80,7 +77,7 @@ class IndexPageGeneratorTest {
             generator.process(project, mockRenderer, mockFileH, clean = true)
 
             // Verify that the output file was created
-            verify { mockFileH.writeFile(outputFile, "index.html", "<html></html>") }
+            verify { mockFileH.writeFile(project.dirs.output, "index.html", "<html></html>") }
         }
     }
 

--- a/src/test/kotlin/org/liamjd/bascule/render/ForEachHelperTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/render/ForEachHelperTest.kt
@@ -1,0 +1,55 @@
+package org.liamjd.bascule.render
+
+import com.github.jknack.handlebars.Handlebars
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Exercises the custom `#forEach` block helper through a real Handlebars instance. `#forEach` behaves
+ * like `#each` but accepts an optional positional limit and exposes extra loop variables.
+ */
+class ForEachHelperTest {
+
+	private val handlebars = Handlebars().apply {
+		registerHelper("forEach", ForEachHelper())
+	}
+
+	private fun render(template: String, context: Any?): String =
+		handlebars.compileInline(template).apply(context)
+
+	@Test
+	fun `iterates over every element when no limit is given`() {
+		assertEquals("a,b,c,", render("{{#forEach this}}{{this}},{{/forEach}}", listOf("a", "b", "c")))
+	}
+
+	@Test
+	fun `honours a positional limit`() {
+		assertEquals("a,b,", render("{{#forEach this \"2\"}}{{this}},{{/forEach}}", listOf("a", "b", "c")))
+	}
+
+	@Test
+	fun `renders the inverse block for an empty collection`() {
+		assertEquals("none", render("{{#forEach this}}{{this}}{{else}}none{{/forEach}}", emptyList<String>()))
+	}
+
+	@Test
+	fun `exposes a one-based index via index_1`() {
+		assertEquals("1.2.3.", render("{{#forEach this}}{{@index_1}}.{{/forEach}}", listOf("a", "b", "c")))
+	}
+
+	@Test
+	fun `flags the first and last elements`() {
+		assertEquals(
+			"first;last;",
+			render("{{#forEach this}}{{@first}}{{@last}};{{/forEach}}", listOf("a", "b"))
+		)
+	}
+
+	@Test
+	fun `alternates odd and even markers`() {
+		assertEquals(
+			"even,odd,even,",
+			render("{{#forEach this}}{{@even}}{{@odd}},{{/forEach}}", listOf("a", "b", "c"))
+		)
+	}
+}

--- a/src/test/kotlin/org/liamjd/bascule/render/LocalDateFormatterTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/render/LocalDateFormatterTest.kt
@@ -1,0 +1,48 @@
+package org.liamjd.bascule.render
+
+import com.github.jknack.handlebars.Handlebars
+import java.time.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Exercises [LocalDateFormatter] through a real Handlebars instance, since the helper's behaviour
+ * depends on the positional params / hash supplied by the template engine.
+ */
+class LocalDateFormatterTest {
+
+	private val handlebars = Handlebars().apply {
+		registerHelper("localDate", LocalDateFormatter())
+	}
+
+	private val date = LocalDate.of(2026, 1, 9)
+
+	private fun render(template: String, context: Any?): String =
+		handlebars.compileInline(template).apply(context)
+
+	@Test
+	fun `uses the default input format when none is supplied`() {
+		assertEquals("09/01/2026", render("{{localDate this}}", date))
+	}
+
+	@Test
+	fun `formats a date using a custom pattern from the format hash`() {
+		assertEquals("2026-01-09", render("{{localDate this format=\"yyyy-MM-dd\"}}", date))
+	}
+
+	@Test
+	fun `formats a date using a positional custom pattern`() {
+		assertEquals("09-01-2026", render("{{localDate this \"dd-MM-yyyy\"}}", date))
+	}
+
+	@Test
+	fun `formats a date using the named ISO_DATE format`() {
+		assertEquals("2026-01-09", render("{{localDate this \"ISO_DATE\"}}", date))
+	}
+
+	@Test
+	fun `falls back to ISO_LOCAL_DATE when the pattern is invalid`() {
+		// A lone single-quote is an unterminated literal, which DateTimeFormatter rejects.
+		assertEquals("2026-01-09", render("{{localDate this \"'\"}}", date))
+	}
+}

--- a/src/test/kotlin/org/liamjd/bascule/render/PaginateTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/render/PaginateTest.kt
@@ -1,0 +1,54 @@
+package org.liamjd.bascule.render
+
+import com.github.jknack.handlebars.Handlebars
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Exercises the custom `#paginate` block helper. It iterates a list of page tokens (page numbers plus
+ * the special markers "*" for the current page and "." for an ellipsis), exposing per-token loop
+ * variables. Positional params are the current page and the total page count.
+ */
+class PaginateTest {
+
+	private val handlebars = Handlebars().apply {
+		registerHelper("paginate", Paginate())
+	}
+
+	private fun render(template: String, context: Any?): String =
+		handlebars.compileInline(template).apply(context)
+
+	@Test
+	fun `emits the page number and flags first and last tokens`() {
+		val result = render(
+			"{{#paginate this 1 3}}{{@page}}:{{@first}}{{@last}};{{/paginate}}",
+			listOf("1", "2", "3")
+		)
+		assertEquals("1:first;2:;3:last;", result)
+	}
+
+	@Test
+	fun `flags the current-page and ellipsis markers`() {
+		val result = render(
+			"{{#paginate this 1 5}}{{@current}}{{@ellipsis}}|{{/paginate}}",
+			listOf("1", "*", ".")
+		)
+		assertEquals("|current|ellipsis|", result)
+	}
+
+	@Test
+	fun `leaves the page variable blank for non-numeric tokens`() {
+		val result = render(
+			"{{#paginate this 1 5}}[{{@page}}]{{/paginate}}",
+			listOf("1", "*", ".")
+		)
+		assertEquals("[1][][]", result)
+	}
+
+	@Test
+	fun `returns an explanatory message when the context is not iterable`() {
+		val result = render("{{#paginate this 1 3}}body{{/paginate}}", 42)
+		assertTrue(result.contains("not iterable"), "expected a not-iterable message but got: $result")
+	}
+}

--- a/src/test/kotlin/org/liamjd/bascule/scanner/ChangeSetCalculatorTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/scanner/ChangeSetCalculatorTest.kt
@@ -1,0 +1,194 @@
+package org.liamjd.bascule.scanner
+
+import com.vladsch.flexmark.parser.Parser
+import com.vladsch.flexmark.util.data.MutableDataSet
+import io.mockk.every
+import io.mockk.mockk
+import org.liamjd.bascule.BasculeFileHandler
+import org.liamjd.bascule.FakeFileScanner
+import org.liamjd.bascule.cache.HandlebarsTemplateCacheItem
+import org.liamjd.bascule.cache.MDCacheItem
+import org.liamjd.bascule.cache.DateConversions
+import org.liamjd.bascule.lib.model.Project
+import org.liamjd.bascule.model.BasculePost
+import org.liamjd.bascule.model.PostGenError
+import java.io.File
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.TimeZone
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [ChangeSetCalculator.calculateUncachedSet], driven entirely through fakes/mocks:
+ * a [FakeFileScanner] supplies the (in-memory) directory tree and file metadata, and [PostBuilder] is
+ * mocked so no markdown parsing / Koin YAML visitor is required.
+ */
+class ChangeSetCalculatorTest {
+
+	private val yamlConfig = """
+        siteName: Test Site
+        dateFormat: "dd/MM/yyyy"
+        dateTimeFormat: HH:mm:ss dd/MM/yyyy
+        author: Tester
+        theme: liamjd-theme
+        postsPerPage: 10
+        directories:
+          source: sources
+          output: site
+          assets: assets
+          templates: liamjd-theme/templates
+          generators: [IndexPageGenerator, PostNavigationGenerator, TaxonomyNavigationGenerator]
+    """.trimIndent()
+
+	private val project = Project(yamlConfig = yamlConfig)
+	private val sourcesDir: File = project.dirs.sources
+
+	private val emptyDocument = Parser.builder(MutableDataSet()).build().parse("")
+
+	private val fileHandler = mockk<BasculeFileHandler>()
+	private val postBuilder = mockk<PostBuilder>()
+	private val fileScanner = FakeFileScanner()
+
+	private val calculator = ChangeSetCalculator(project, fileHandler, postBuilder, fileScanner)
+
+	private fun post(layout: String = "post", slug: String, title: String = slug, date: LocalDate = LocalDate.of(2026, 1, 1)): BasculePost {
+		val p = BasculePost(emptyDocument)
+		p.layout = layout
+		p.slug = slug
+		p.title = title
+		p.date = date
+		return p
+	}
+
+	private fun stubFileHandlerForRenderPath() {
+		// getFile mirrors the real File(folder, name); readFileAsString returns canned content
+		every { fileHandler.getFile(any(), any()) } answers { File(firstArg<File>(), secondArg<String>()) }
+		every { fileHandler.readFileAsString(any<File>(), any<String>()) } returns "raw markdown"
+	}
+
+	@Test
+	fun `new markdown files in a clean build are all flagged for rerender`() {
+		project.clean = true
+		stubFileHandlerForRenderPath()
+
+		val fileA = File(sourcesDir, "a.md")
+		val fileB = File(sourcesDir, "b.md")
+		fileScanner
+			.addDirectory(sourcesDir, listOf(fileA, fileB))
+			.addFile(fileA, length = 10L, lastModified = 1_000L)
+			.addFile(fileB, length = 20L, lastModified = 2_000L)
+
+		every { postBuilder.buildPost(fileA) } returns post(slug = "a")
+		every { postBuilder.buildPost(fileB) } returns post(slug = "b")
+
+		val result = calculator.calculateUncachedSet(emptySet(), emptySet())
+
+		assertEquals(2, result.size)
+		assertTrue(result.all { it.mdCacheItem.rerender })
+		// url is derived from the slug for top-level posts
+		assertEquals(setOf("a.html", "b.html"), result.map { it.mdCacheItem.link.url }.toSet())
+	}
+
+	@Test
+	fun `draft files, draft folders and non-markdown files are skipped`() {
+		project.clean = true
+		stubFileHandlerForRenderPath()
+
+		val published = File(sourcesDir, "published.md")
+		val draftFile = File(sourcesDir, ".secret.md")
+		val underscoreDraft = File(sourcesDir, "__wip.md")
+		val notMarkdown = File(sourcesDir, "styles.css")
+		fileScanner
+			.addDirectory(sourcesDir, listOf(published, draftFile, underscoreDraft, notMarkdown))
+			.addFile(published, length = 10L, lastModified = 1_000L)
+			.addFile(draftFile, length = 10L, lastModified = 1_000L)
+			.addFile(underscoreDraft, length = 10L, lastModified = 1_000L)
+			.addFile(notMarkdown, length = 10L, lastModified = 1_000L)
+
+		every { postBuilder.buildPost(published) } returns post(slug = "published")
+
+		val result = calculator.calculateUncachedSet(emptySet(), emptySet())
+
+		assertEquals(1, result.size)
+		assertEquals("published.html", result.first().mdCacheItem.link.url)
+	}
+
+	@Test
+	fun `markdown files in nested directories are discovered recursively`() {
+		project.clean = true
+		stubFileHandlerForRenderPath()
+
+		val subDir = File(sourcesDir, "blog")
+		val nested = File(subDir, "nested.md")
+		fileScanner
+			.addDirectory(sourcesDir, listOf(subDir))
+			.addDirectory(subDir, listOf(nested))
+			.addFile(nested, length = 30L, lastModified = 3_000L)
+
+		every { postBuilder.buildPost(nested) } returns post(slug = "nested")
+
+		val result = calculator.calculateUncachedSet(emptySet(), emptySet())
+
+		assertEquals(1, result.size)
+		assertEquals("nested", result.first().post?.slug)
+	}
+
+	@Test
+	fun `files that fail to parse are excluded from the change set`() {
+		project.clean = true
+		stubFileHandlerForRenderPath()
+
+		val good = File(sourcesDir, "good.md")
+		val bad = File(sourcesDir, "bad.md")
+		fileScanner
+			.addDirectory(sourcesDir, listOf(good, bad))
+			.addFile(good, length = 10L, lastModified = 1_000L)
+			.addFile(bad, length = 10L, lastModified = 1_000L)
+
+		every { postBuilder.buildPost(good) } returns post(slug = "good")
+		every { postBuilder.buildPost(bad) } returns PostGenError("missing title", "bad.md", "title")
+
+		val result = calculator.calculateUncachedSet(emptySet(), emptySet())
+
+		assertEquals(1, result.size)
+		assertEquals("good.html", result.first().mdCacheItem.link.url)
+	}
+
+	@Test
+	fun `an unchanged file with an unchanged template is served from cache without rerender`() {
+		project.clean = false
+		stubFileHandlerForRenderPath()
+
+		val fileA = File(sourcesDir, "a.md")
+		val length = 10L
+		val modifiedMillis = 1_700_000_000_000L
+		fileScanner
+			.addDirectory(sourcesDir, listOf(fileA))
+			.addFile(fileA, length = length, lastModified = modifiedMillis)
+
+		every { postBuilder.buildPost(fileA) } returns post(slug = "a")
+
+		// the cached item must match on path + size + modification date exactly (same derivation as walkFolder)
+		val modDateTime = LocalDateTime.ofInstant(
+			Instant.ofEpochMilli(modifiedMillis), TimeZone.getDefault().toZoneId()
+		)
+		val cachedItem = MDCacheItem(length, fileA.absolutePath, modDateTime)
+
+		// the template is also unchanged: its cached mod-date must equal the file's lastModified (in seconds)
+		val templateFile = File("templates", "post.hbs")
+		every { fileHandler.getFile(project.dirs.templates, "post.hbs") } returns templateFile
+		val templateLdt = LocalDateTime.of(2026, 1, 1, 12, 0, 0)
+		val templateEpochSeconds = DateConversions.localDateTimeToEpochSeconds(templateLdt)
+		fileScanner.addFile(templateFile, lastModified = templateEpochSeconds * 1000)
+		val layoutSet = setOf(HandlebarsTemplateCacheItem("post", templateFile.path, 0L, templateLdt))
+
+		val result = calculator.calculateUncachedSet(setOf(cachedItem), layoutSet)
+
+		assertEquals(1, result.size)
+		assertFalse(result.first().mdCacheItem.rerender, "an unchanged file+template should not be re-rendered")
+	}
+}

--- a/src/test/kotlin/org/liamjd/bascule/scanner/MarkdownScannerTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/scanner/MarkdownScannerTest.kt
@@ -1,0 +1,95 @@
+package org.liamjd.bascule.scanner
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.liamjd.bascule.cache.BasculeCache
+import org.liamjd.bascule.cache.CacheAndPost
+import org.liamjd.bascule.cache.MDCacheItem
+import org.liamjd.bascule.lib.model.PostLink
+import org.liamjd.bascule.lib.model.Project
+import java.time.LocalDate
+import java.time.LocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Unit tests for [MarkdownScanner.calculateRenderSet]. Its collaborators (the cache and the change-set
+ * calculator) are mocked, so the test exercises only the scanner's own orchestration: load -> calculate
+ * -> sort/link -> write cache -> return.
+ */
+class MarkdownScannerTest {
+
+	private val yamlConfig = """
+        siteName: Test Site
+        dateFormat: "dd/MM/yyyy"
+        dateTimeFormat: HH:mm:ss dd/MM/yyyy
+        author: Tester
+        theme: liamjd-theme
+        postsPerPage: 10
+        directories:
+          source: sources
+          output: site
+          assets: assets
+          templates: liamjd-theme/templates
+          generators: [IndexPageGenerator, PostNavigationGenerator, TaxonomyNavigationGenerator]
+    """.trimIndent()
+
+	private val project = Project(yamlConfig = yamlConfig).apply { clean = false }
+
+	private val cache = mockk<BasculeCache>()
+	private val changeSetCalculator = mockk<ChangeSetCalculator>()
+
+	private val scanner = MarkdownScanner(project, cache, changeSetCalculator)
+
+	private fun item(slug: String, date: LocalDate, layout: String = "post"): CacheAndPost {
+		val md = MDCacheItem(10L, "/sources/$slug.md", LocalDateTime.of(2026, 1, 1, 0, 0))
+		md.layout = layout
+		md.link = PostLink(slug, "$slug.html", date)
+		return CacheAndPost(md, null)
+	}
+
+	@Test
+	fun `calculateRenderSet returns the uncached set produced by the change calculator`() {
+		val uncached = setOf(
+			item("a", LocalDate.of(2026, 1, 1)),
+			item("b", LocalDate.of(2026, 2, 1))
+		)
+		every { cache.loadCacheFile() } returns emptySet()
+		every { changeSetCalculator.calculateUncachedSet(any(), any()) } returns uncached
+		every { cache.writeCacheFile(any()) } just Runs
+
+		val result = scanner.calculateRenderSet(useCache = true)
+
+		assertEquals(uncached, result)
+	}
+
+	@Test
+	fun `the merged set of cached and new items is written back to the cache`() {
+		val uncached = setOf(
+			item("a", LocalDate.of(2026, 1, 1)),
+			item("b", LocalDate.of(2026, 2, 1))
+		)
+		every { cache.loadCacheFile() } returns emptySet()
+		every { changeSetCalculator.calculateUncachedSet(any(), any()) } returns uncached
+		every { cache.writeCacheFile(any()) } just Runs
+
+		scanner.calculateRenderSet(useCache = true)
+
+		// both new items should be persisted to the cache
+		verify { cache.writeCacheFile(match { items -> items.size == 2 }) }
+	}
+
+	@Test
+	fun `when caching is disabled the cache file is not loaded and an empty cached set is used`() {
+		every { changeSetCalculator.calculateUncachedSet(any(), any()) } returns emptySet()
+		every { cache.writeCacheFile(any()) } just Runs
+
+		scanner.calculateRenderSet(useCache = false)
+
+		verify(exactly = 0) { cache.loadCacheFile() }
+		verify { changeSetCalculator.calculateUncachedSet(emptySet(), emptySet()) }
+	}
+}

--- a/src/test/kotlin/org/liamjd/bascule/scanner/ScannerFunctionsTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/scanner/ScannerFunctionsTest.kt
@@ -1,0 +1,149 @@
+package org.liamjd.bascule.scanner
+
+import org.liamjd.bascule.cache.CacheAndPost
+import org.liamjd.bascule.cache.MDCacheItem
+import org.liamjd.bascule.lib.model.PostLink
+import java.io.File
+import java.time.LocalDate
+import java.time.LocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the pure helpers extracted from the scanner. No filesystem or Koin required.
+ */
+class ScannerFunctionsTest {
+
+	// ---- isDraftName ------------------------------------------------------
+
+	@Test
+	fun `names starting with a dot are drafts`() = assertTrue(isDraftName(".draft.md"))
+
+	@Test
+	fun `names starting with double underscore are drafts`() = assertTrue(isDraftName("__wip"))
+
+	@Test
+	fun `ordinary names are not drafts`() = assertFalse(isDraftName("published.md"))
+
+	@Test
+	fun `a single underscore is not a draft`() = assertFalse(isDraftName("_partial.md"))
+
+	// ---- isMarkdownFile ---------------------------------------------------
+
+	@Test
+	fun `lowercase md extension is markdown`() = assertTrue(isMarkdownFile(File("post.md")))
+
+	@Test
+	fun `uppercase MD extension is markdown`() = assertTrue(isMarkdownFile(File("POST.MD")))
+
+	@Test
+	fun `non-md extensions are not markdown`() {
+		assertFalse(isMarkdownFile(File("style.css")))
+		assertFalse(isMarkdownFile(File("noextension")))
+	}
+
+	// ---- calculateUrl -----------------------------------------------------
+
+	@Test
+	fun `url for an empty source path is just the slug`() {
+		assertEquals("my-post.html", calculateUrl("my-post", ""))
+	}
+
+	@Test
+	fun `url for a nested source path is normalised to forward slashes`() {
+		assertEquals("blog/2026/my-post.html", calculateUrl("my-post", "\\blog\\2026"))
+	}
+
+	@Test
+	fun `url strips a single leading backslash from the source path`() {
+		assertEquals("blog/my-post.html", calculateUrl("my-post", "\\blog"))
+	}
+
+	// ---- cacheContainsItem ------------------------------------------------
+
+	private val modDate = LocalDateTime.of(2026, 5, 31, 12, 0, 0)
+	private fun item(path: String, size: Long = 100L, date: LocalDateTime = modDate) =
+		MDCacheItem(sourceFileSize = size, sourceFilePath = path, sourceModificationDate = date)
+
+	@Test
+	fun `cache hit when path, size and date all match`() {
+		val cached = setOf(item("/sources/a.md"))
+		assertTrue(cacheContainsItem(item("/sources/a.md"), cached))
+	}
+
+	@Test
+	fun `cache miss when the size differs`() {
+		val cached = setOf(item("/sources/a.md", size = 100L))
+		assertFalse(cacheContainsItem(item("/sources/a.md", size = 200L), cached))
+	}
+
+	@Test
+	fun `cache miss when the modification date differs`() {
+		val cached = setOf(item("/sources/a.md", date = modDate))
+		assertFalse(cacheContainsItem(item("/sources/a.md", date = modDate.plusSeconds(1)), cached))
+	}
+
+	@Test
+	fun `cache miss when the path is unknown`() {
+		val cached = setOf(item("/sources/a.md"))
+		assertFalse(cacheContainsItem(item("/sources/b.md"), cached))
+	}
+
+	// ---- sortAndLinkPosts -------------------------------------------------
+
+	private fun post(path: String, date: LocalDate, layout: String = "post"): CacheAndPost {
+		val mdItem = item(path)
+		mdItem.layout = layout
+		mdItem.link = PostLink(path, "$path.html", date)
+		return CacheAndPost(mdItem, post = null)
+	}
+
+	@Test
+	fun `posts are sorted ascending by date`() {
+		val unsorted = setOf(
+			post("c", LocalDate.of(2026, 3, 1)),
+			post("a", LocalDate.of(2026, 1, 1)),
+			post("b", LocalDate.of(2026, 2, 1))
+		)
+		val ordered = sortAndLinkPosts(unsorted, "post").map { it.mdCacheItem.link.title }
+		assertEquals(listOf("a", "b", "c"), ordered)
+	}
+
+	@Test
+	fun `previous and next links are wired across the ordered posts`() {
+		val a = post("a", LocalDate.of(2026, 1, 1))
+		val b = post("b", LocalDate.of(2026, 2, 1))
+		val c = post("c", LocalDate.of(2026, 3, 1))
+
+		sortAndLinkPosts(setOf(c, a, b), "post")
+
+		// middle post points both ways
+		assertEquals("a.html", b.mdCacheItem.previous?.url)
+		assertEquals("c.html", b.mdCacheItem.next?.url)
+		// ends are open
+		assertNull(a.mdCacheItem.previous)
+		assertNull(c.mdCacheItem.next)
+		assertEquals("b.html", a.mdCacheItem.next?.url)
+		assertEquals("b.html", c.mdCacheItem.previous?.url)
+	}
+
+	@Test
+	fun `non-post layouts are excluded from the navigation chain`() {
+		val page = post("about", LocalDate.of(2026, 1, 15), layout = "page")
+		val p1 = post("first", LocalDate.of(2026, 1, 1))
+		val p2 = post("second", LocalDate.of(2026, 2, 1))
+
+		val result = sortAndLinkPosts(setOf(page, p1, p2), "post")
+
+		// the page is still in the sorted set ...
+		assertTrue(result.any { it.mdCacheItem.link.title == "about" })
+		// ... but is not linked, and the two posts link directly to each other
+		assertNull(page.mdCacheItem.previous)
+		assertNull(page.mdCacheItem.next)
+		assertEquals("second.html", p1.mdCacheItem.next?.url)
+		assertEquals("first.html", p2.mdCacheItem.previous?.url)
+	}
+}

--- a/src/test/kotlin/org/liamjd/bascule/scanner/ScannerKoinWiringTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/scanner/ScannerKoinWiringTest.kt
@@ -1,0 +1,71 @@
+package org.liamjd.bascule.scanner
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.koin.core.Koin
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.parameter.parametersOf
+import org.liamjd.bascule.BasculeFileHandler
+import org.liamjd.bascule.fileModule
+import org.liamjd.bascule.generationModule
+import org.liamjd.bascule.lib.model.Project
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+/**
+ * Verifies that the Koin factories for the scanner classes still resolve after the move to constructor
+ * injection (Step 1 of the testability refactor). Compilation alone does not prove that
+ * `get { parametersOf(project) }` wires up correctly at runtime.
+ */
+class ScannerKoinWiringTest {
+
+	private val yamlConfig = """
+        siteName: Liam John Davison
+        dateFormat: "dd/MM/yyyy"
+        dateTimeFormat: HH:mm:ss dd/MM/yyyy
+        author: Liam Davison
+        theme: liamjd-theme
+        postsPerPage: 10
+        directories:
+          source: sources
+          output: site
+          assets: assets
+          templates: liamjd-theme/templates
+          generators: [IndexPageGenerator, PostNavigationGenerator, TaxonomyNavigationGenerator]
+    """.trimIndent()
+
+	private val project = Project(yamlConfig = yamlConfig)
+	private lateinit var koin: Koin
+
+	@BeforeEach
+	fun setUp() {
+		koin = startKoin { modules(fileModule, generationModule) }.koin
+	}
+
+	@AfterEach
+	fun tearDown() = stopKoin()
+
+	@Test
+	fun `PostBuilder resolves from Koin`() {
+		assertNotNull(koin.get<PostBuilder> { parametersOf(project) })
+	}
+
+	@Test
+	fun `ChangeSetCalculator resolves from Koin with its fileHandler and postBuilder`() {
+		assertNotNull(koin.get<ChangeSetCalculator> { parametersOf(project) })
+	}
+
+	@Test
+	fun `MarkdownScanner resolves from Koin with its full dependency chain`() {
+		// This is the deepest chain: MarkdownScanner -> BasculeCache + ChangeSetCalculator -> PostBuilder + FileHandler
+		assertNotNull(koin.get<MarkdownScanner> { parametersOf(project) })
+	}
+
+	@Test
+	fun `PostBuilder can also be constructed directly with a FileHandler, no Koin needed`() {
+		// the point of the refactor: no global container required to build the object
+		val postBuilder = PostBuilder(project, BasculeFileHandler())
+		assertNotNull(postBuilder)
+	}
+}


### PR DESCRIPTION
This pull request introduces several important refactorings and improvements to the codebase, primarily focused on decoupling file system operations for improved testability, centralizing date conversion logic, and updating dependency injection wiring. These changes make the project easier to test and maintain, especially around the change-set calculation and post-building pipeline.

**Testability & File System Abstraction:**
- Introduced a new `FileScanner` interface to abstract file system operations (listing files, checking directories, file size, and modification time), allowing for easier mocking and unit testing of file-dependent logic. `BasculeFileHandler` now implements this interface. [[1]](diffhunk://#diff-5a082a41e17bcd32c4d0cd45a9310070412324c4c552cc9abf92a549cf81c5daR1-R26) [[2]](diffhunk://#diff-ae139ec46ae9c0981f03024804331e929445ff4cb406e5ba66f1cbf190cac6deL15-R27)
- Updated `ChangeSetCalculator` and `MarkdownScanner` to depend on `FileScanner` rather than directly using `File` APIs, further decoupling file system interactions from core logic. [[1]](diffhunk://#diff-ac3043608d8fcdd50c26d3f6d35790aadb8004b4e66d74bd7519a87dd9a1c4b5L4-R7) [[2]](diffhunk://#diff-ac3043608d8fcdd50c26d3f6d35790aadb8004b4e66d74bd7519a87dd9a1c4b5L36-L39) [[3]](diffhunk://#diff-ac3043608d8fcdd50c26d3f6d35790aadb8004b4e66d74bd7519a87dd9a1c4b5L133-R139)

**Dependency Injection & Construction:**
- Refactored Koin DI modules to inject the new dependencies and updated constructors for `PostBuilder`, `ChangeSetCalculator`, and `MarkdownScanner` to accept the correct parameters, ensuring all dependencies are properly wired. [[1]](diffhunk://#diff-c9f71bfac86f27884b3f891fb8909ab3f8987c8a5532fbe455362548241eaed4R12-R33) [[2]](diffhunk://#diff-c9f71bfac86f27884b3f891fb8909ab3f8987c8a5532fbe455362548241eaed4L3-R3) [[3]](diffhunk://#diff-e21f19ff0379f1863235e2067f79c835271a2254b66b7bc031686db52038e8f9L34-R34) [[4]](diffhunk://#diff-e840e80d4b6ca6c75e58136a717d6760eaf936e9bdc27e77b9b407390e17872dL136-R137)

**Date Handling Improvements:**
- Centralized all date-to-epoch-seconds and epoch-seconds-to-date conversions in a new `DateConversions` object, removing duplicated implementations and reducing potential for inconsistencies. Updated `PostLinkSerializer` and `ChangeSetCalculator` to use this utility. [[1]](diffhunk://#diff-1df205a5540877199446713a26a438fe9d6134c494b85ff5b09f35d432aac299R1-R29) [[2]](diffhunk://#diff-c36906ccbca7a478b2fc2f4e44aeaa4fc40a81647454c60a46ec29db15927ff5L31-R29) [[3]](diffhunk://#diff-c36906ccbca7a478b2fc2f4e44aeaa4fc40a81647454c60a46ec29db15927ff5L49-R47) [[4]](diffhunk://#diff-c36906ccbca7a478b2fc2f4e44aeaa4fc40a81647454c60a46ec29db15927ff5L60-L69)

**Code Quality & Bug Fixes:**
- Fixed a bug in `MDCacheItem.equals` where it incorrectly compared the same field (`this.sourceFilePath == this.sourceFilePath`) instead of comparing with the other object.
- Removed unnecessary KoinComponent/inject usage from `BasculePost.Builder` and updated its `createPostFromYaml` signature to accept the YAML visitor explicitly, further reducing DI complexity. [[1]](diffhunk://#diff-8211e83c0307e47e5968daf60efc7f044851ed2b0f5b723bc8055674cb3f9287L76-R74) [[2]](diffhunk://#diff-8211e83c0307e47e5968daf60efc7f044851ed2b0f5b723bc8055674cb3f9287L89-R92)

**Documentation:**
- Added a comprehensive `CLAUDE.md` file describing the project architecture, build/run instructions, dependency injection, generation pipeline, key types, caching, templating, plugin system, and testing notes.