### PR TITLE
Adding new model attributes __now and __nowDate at the render stage.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "org.liamjd"
-version = "0.5.2"
+version = "0.5.3"
 
 plugins {
     alias(libs.plugins.kotlin.jvm)

--- a/src/main/kotlin/org/liamjd/bascule/render/HandlebarsRenderer.kt
+++ b/src/main/kotlin/org/liamjd/bascule/render/HandlebarsRenderer.kt
@@ -10,45 +10,62 @@ import com.github.jknack.handlebars.helper.StringHelpers
 import com.github.jknack.handlebars.io.FileTemplateLoader
 import org.liamjd.bascule.lib.model.Project
 import org.liamjd.bascule.lib.render.TemplatePageRenderer
+import java.time.LocalDate
+import java.time.LocalDateTime
 
+/**
+ * Renders a template using the Handlebars template engine.
+ * @param project the project configuration
+ */
 class HandlebarsRenderer(val project: Project) : TemplatePageRenderer {
 
-	val TEMPLATE_SUFFIX = ".hbs"
-	val hbRenderer: Handlebars
-	val dateFormat: String
-	val loader: FileTemplateLoader
+    val TEMPLATE_SUFFIX = ".hbs"
+    val hbRenderer: Handlebars
+    val dateFormat: String
+    val loader: FileTemplateLoader
 
-	init {
-		loader = FileTemplateLoader(project.dirs.templates)
-		dateFormat = project.model["dateFormat"] as String? ?: "dd/MMM/yyyy"
+    init {
+        loader = FileTemplateLoader(project.dirs.templates)
+        dateFormat = project.model["dateFormat"] as String? ?: "dd/MMM/yyyy"
 
-		hbRenderer = Handlebars(loader)
-		hbRenderer.registerHelper("forEach", ForEachHelper())
-		hbRenderer.registerHelper("paginate", Paginate())
-		hbRenderer.registerHelper("localDate", LocalDateFormatter(dateFormat))
-		hbRenderer.registerHelper("capitalize",StringHelpers.capitalize)
-		hbRenderer.registerHelper("upper",StringHelpers.upper)
-		hbRenderer.registerHelper("slugify", StringHelpers.slugify)
-	}
+        hbRenderer = Handlebars(loader)
+        hbRenderer.registerHelper("forEach", ForEachHelper())
+        hbRenderer.registerHelper("paginate", Paginate())
+        hbRenderer.registerHelper("localDate", LocalDateFormatter(dateFormat))
+        hbRenderer.registerHelper("capitalize", StringHelpers.capitalize)
+        hbRenderer.registerHelper("upper", StringHelpers.upper)
+        hbRenderer.registerHelper("slugify", StringHelpers.slugify)
+    }
 
-	override fun render(model: Map<String, Any?>, templateName: String): String {
-		val hbContext = Context.newBuilder(model).resolver(MethodValueResolver.INSTANCE, JavaBeanValueResolver.INSTANCE, MapValueResolver.INSTANCE, FieldValueResolver.INSTANCE).build()
+    override fun render(model: Map<String, Any?>, templateName: String): String {
+        // add date and time; may want to expand on this capability
+        val updatedModel = mutableMapOf<String, Any?>()
+        updatedModel.putAll(model)
+        updatedModel["__nowDate"] = LocalDate.now()
+        updatedModel["__now"] = LocalDateTime.now()
 
-		val template = hbRenderer.compileInline(getTemplateText(project, templateName))
+        val hbContext = Context.newBuilder(updatedModel).resolver(
+            MethodValueResolver.INSTANCE,
+            JavaBeanValueResolver.INSTANCE,
+            MapValueResolver.INSTANCE,
+            FieldValueResolver.INSTANCE
+        ).build()
 
-		return template.apply(hbContext)
-	}
+        val template = hbRenderer.compileInline(getTemplateText(project, templateName))
 
-	private fun getTemplateText(project: Project, templateName: String): String {
-		val matches = project.dirs.templates.listFiles { _, name -> name == (templateName  + TEMPLATE_SUFFIX) }
+        return template.apply(hbContext)
+    }
 
-		if (matches != null) {
-			if (matches.isNotEmpty() && matches.size == 1) {
-				val found = matches[0]
-				return found.readText()
-			}
-		}
-		println.error("ERROR - template file '$templateName' not found - unable to generate content.")
-		return ""
-	}
+    private fun getTemplateText(project: Project, templateName: String): String {
+        val matches = project.dirs.templates.listFiles { _, name -> name == (templateName + TEMPLATE_SUFFIX) }
+
+        if (matches != null) {
+            if (matches.isNotEmpty() && matches.size == 1) {
+                val found = matches[0]
+                return found.readText()
+            }
+        }
+        println.error("ERROR - template file '$templateName' not found - unable to generate content.")
+        return ""
+    }
 }

--- a/src/main/kotlin/org/liamjd/bascule/render/LocalDateFormatter.kt
+++ b/src/main/kotlin/org/liamjd/bascule/render/LocalDateFormatter.kt
@@ -4,46 +4,50 @@ import com.github.jknack.handlebars.Helper
 import com.github.jknack.handlebars.Options
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.time.temporal.Temporal
 
 /**
  * Only handles LocalDate with no time component
  */
 class LocalDateFormatter(val inputFormat: String = "dd/MM/yyyy") : Helper<Any> {
 
-	private val ISO_DATE = "ISO_DATE"
-	private val ISO_LOCAL_DATE = "ISO_LOCAL_DATE"
-	private val ISO_ORDINAL_DATE = "ISO_ORDINAL_DATE"
-	private val ISO_WEEK_DATE = "ISO_WEEK_DATE"
+    private val ISO_DATE = "ISO_DATE"
+    private val ISO_LOCAL_DATE = "ISO_LOCAL_DATE"
+    private val ISO_ORDINAL_DATE = "ISO_ORDINAL_DATE"
+    private val ISO_WEEK_DATE = "ISO_WEEK_DATE"
 
-	override fun apply(value: Any?, options: Options): CharSequence {
+    override fun apply(value: Any?, options: Options): CharSequence {
 
-		if (value != null) {
-			val format = options.param(0, options.hash<Any>("format", inputFormat)) as String
-			val outputFormatter = when (format) {
-				ISO_DATE -> {
-					DateTimeFormatter.ISO_DATE
-				}
-				ISO_LOCAL_DATE -> {
-					DateTimeFormatter.ISO_LOCAL_DATE
-				}
-				ISO_ORDINAL_DATE -> {
-					DateTimeFormatter.ISO_ORDINAL_DATE
-				}
-				ISO_WEEK_DATE -> {
-					DateTimeFormatter.ISO_WEEK_DATE
-				}
-				else -> {
-					try {
-						DateTimeFormatter.ofPattern(format)
-					}  catch (iae: IllegalArgumentException) {
-						println("Could not parse localDate format string '$format'; reverting to ISO_LOCAL_DATE")
-						DateTimeFormatter.ISO_LOCAL_DATE
-					}
-				}
-			}
-			val result = outputFormatter.format(value as LocalDate)
-			return result
-		}
-		return LocalDate.now().toString()
-	}
+        // check that value is a valid temporal type
+        if (value !is Temporal) throw IllegalArgumentException("LocalDateFormatter only supports Temporal; got ${value?.javaClass?.name}")
+        val format = options.param(0, options.hash<Any>("format", inputFormat)) as String
+        val outputFormatter = when (format) {
+            ISO_DATE -> {
+                DateTimeFormatter.ISO_DATE
+            }
+
+            ISO_LOCAL_DATE -> {
+                DateTimeFormatter.ISO_LOCAL_DATE
+            }
+
+            ISO_ORDINAL_DATE -> {
+                DateTimeFormatter.ISO_ORDINAL_DATE
+            }
+
+            ISO_WEEK_DATE -> {
+                DateTimeFormatter.ISO_WEEK_DATE
+            }
+
+            else -> {
+                try {
+                    DateTimeFormatter.ofPattern(format)
+                } catch (iae: IllegalArgumentException) {
+                    println("Could not parse localDate format string '$format'; reverting to ISO_LOCAL_DATE")
+                    DateTimeFormatter.ISO_LOCAL_DATE
+                }
+            }
+        }
+        val result = outputFormatter.format(value as LocalDate)
+        return result
+    }
 }

--- a/src/main/kotlin/org/liamjd/bascule/render/MarkdownToHTMLRenderer.kt
+++ b/src/main/kotlin/org/liamjd/bascule/render/MarkdownToHTMLRenderer.kt
@@ -35,7 +35,7 @@ class MarkdownToHTMLRenderer(
         val model = mutableMapOf<String, Any?>()
         model.putAll(siteModel)
         model.putAll(basculePost.toModel())
-        model["\$currentPage"] = basculePost.slug
+        model["__currentPage"] = basculePost.slug
 
         // first, extract the content from the markdown
         val renderedMarkdown = renderMarkdown(basculePost.document)

--- a/src/test/kotlin/org/liamjd/bascule/render/LocalDateFormatterTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/render/LocalDateFormatterTest.kt
@@ -1,9 +1,11 @@
 package org.liamjd.bascule.render
 
 import com.github.jknack.handlebars.Handlebars
+import com.github.jknack.handlebars.HandlebarsException
 import java.time.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 /**
  * Exercises [LocalDateFormatter] through a real Handlebars instance, since the helper's behaviour
@@ -45,4 +47,27 @@ class LocalDateFormatterTest {
 		// A lone single-quote is an unterminated literal, which DateTimeFormatter rejects.
 		assertEquals("2026-01-09", render("{{localDate this \"'\"}}", date))
 	}
+
+	@Test
+	fun `formats a date specified through the now model object`() {
+		val expected = LocalDate.now()
+		val expectedString = expected.format(java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy"))
+		val context = mapOf("__nowDate" to expected)
+		assertEquals(expectedString, render("{{ localDate __nowDate }}", context))
+	}
+
+	@Test
+	fun `formats a date specified through the now model object with positional pattern`() {
+		val expected = LocalDate.now()
+		val expectedString = expected.format(java.time.format.DateTimeFormatter.ofPattern("EEE, dd/MM/yyyy"))
+		val context = mapOf("__nowDate" to expected)
+		assertEquals(expectedString, render("{{ localDate __nowDate \"EEE, dd/MM/yyyy\"}}", context))
+	}
+
+	@Test
+	fun `exception is thrown if a non-date is passed to the helper`() {
+		val context = mapOf("__nowDate" to "not a date")
+		assertFailsWith<HandlebarsException> { render("{{ localDate __nowDate }}", context) }
+	}
+
 }

--- a/src/test/kotlin/org/liamjd/bascule/render/MarkdownToHTMLRendererTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/render/MarkdownToHTMLRendererTest.kt
@@ -1,12 +1,7 @@
 package org.liamjd.bascule.render
 
 import com.vladsch.flexmark.util.ast.Document
-import io.mockk.Runs
-import io.mockk.every
-import io.mockk.just
-import io.mockk.mockk
-import io.mockk.slot
-import io.mockk.verify
+import io.mockk.*
 import org.liamjd.bascule.BasculeFileHandler
 import org.liamjd.bascule.lib.model.Project
 import org.liamjd.bascule.lib.render.TemplatePageRenderer
@@ -18,7 +13,7 @@ import kotlin.test.assertEquals
 
 /**
  * Tests for [MarkdownToHTMLRenderer]. The file handler and template renderer are supplied as mocks
- * via the constructor, so the Flexmark markdown conversion and the render/write orchestration can be
+ * via the constructor, so the Flexmark Markdown conversion and the render/write orchestration can be
  * verified without Koin or the filesystem.
  */
 class MarkdownToHTMLRendererTest {
@@ -103,6 +98,7 @@ class MarkdownToHTMLRendererTest {
         assertEquals(renderedMarkdown, post.content)
         // the post's own fields (via toModel) and the current page marker are present in the model
         assertEquals("My Post", model["title"])
-        assertEquals("my-post", model["\$currentPage"])
+        assertEquals("my-post", model["__currentPage"])
     }
+
 }

--- a/src/test/kotlin/org/liamjd/bascule/scanner/MarkdownScannerTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/scanner/MarkdownScannerTest.kt
@@ -1,10 +1,6 @@
 package org.liamjd.bascule.scanner
 
-import io.mockk.Runs
-import io.mockk.every
-import io.mockk.just
-import io.mockk.mockk
-import io.mockk.verify
+import io.mockk.*
 import org.liamjd.bascule.cache.BasculeCache
 import org.liamjd.bascule.cache.CacheAndPost
 import org.liamjd.bascule.cache.MDCacheItem
@@ -22,7 +18,7 @@ import kotlin.test.assertEquals
  */
 class MarkdownScannerTest {
 
-	private val yamlConfig = """
+    private val yamlConfig = """
         siteName: Test Site
         dateFormat: "dd/MM/yyyy"
         dateTimeFormat: HH:mm:ss dd/MM/yyyy
@@ -37,59 +33,59 @@ class MarkdownScannerTest {
           generators: [IndexPageGenerator, PostNavigationGenerator, TaxonomyNavigationGenerator]
     """.trimIndent()
 
-	private val project = Project(yamlConfig = yamlConfig).apply { clean = false }
+    private val project = Project(yamlConfig = yamlConfig).apply { clean = false }
 
-	private val cache = mockk<BasculeCache>()
-	private val changeSetCalculator = mockk<ChangeSetCalculator>()
+    private val cache = mockk<BasculeCache>()
+    private val changeSetCalculator = mockk<ChangeSetCalculator>()
 
-	private val scanner = MarkdownScanner(project, cache, changeSetCalculator)
+    private val scanner = MarkdownScanner(project, cache, changeSetCalculator)
 
-	private fun item(slug: String, date: LocalDate, layout: String = "post"): CacheAndPost {
-		val md = MDCacheItem(10L, "/sources/$slug.md", LocalDateTime.of(2026, 1, 1, 0, 0))
-		md.layout = layout
-		md.link = PostLink(slug, "$slug.html", date)
-		return CacheAndPost(md, null)
-	}
+    private fun item(slug: String, date: LocalDate, layout: String = "post"): CacheAndPost {
+        val md = MDCacheItem(10L, "/sources/$slug.md", LocalDateTime.of(2026, 1, 1, 0, 0))
+        md.layout = layout
+        md.link = PostLink(slug, "$slug.html", date)
+        return CacheAndPost(md, null)
+    }
 
-	@Test
-	fun `calculateRenderSet returns the uncached set produced by the change calculator`() {
-		val uncached = setOf(
-			item("a", LocalDate.of(2026, 1, 1)),
-			item("b", LocalDate.of(2026, 2, 1))
-		)
-		every { cache.loadCacheFile() } returns emptySet()
-		every { changeSetCalculator.calculateUncachedSet(any(), any()) } returns uncached
-		every { cache.writeCacheFile(any()) } just Runs
+    @Test
+    fun `calculateRenderSet returns the uncached set produced by the change calculator`() {
+        val uncached = setOf(
+            item("a", LocalDate.of(2026, 1, 1)),
+            item("b", LocalDate.of(2026, 2, 1))
+        )
+        every { cache.loadCacheFile() } returns emptySet()
+        every { changeSetCalculator.calculateUncachedSet(any(), any()) } returns uncached
+        every { cache.writeCacheFile(any()) } just Runs
 
-		val result = scanner.calculateRenderSet(useCache = true)
+        val result = scanner.calculateRenderSet(useCache = true)
 
-		assertEquals(uncached, result)
-	}
+        assertEquals(uncached, result)
+    }
 
-	@Test
-	fun `the merged set of cached and new items is written back to the cache`() {
-		val uncached = setOf(
-			item("a", LocalDate.of(2026, 1, 1)),
-			item("b", LocalDate.of(2026, 2, 1))
-		)
-		every { cache.loadCacheFile() } returns emptySet()
-		every { changeSetCalculator.calculateUncachedSet(any(), any()) } returns uncached
-		every { cache.writeCacheFile(any()) } just Runs
+    @Test
+    fun `the merged set of cached and new items is written back to the cache`() {
+        val uncached = setOf(
+            item("a", LocalDate.of(2026, 1, 1)),
+            item("b", LocalDate.of(2026, 2, 1))
+        )
+        every { cache.loadCacheFile() } returns emptySet()
+        every { changeSetCalculator.calculateUncachedSet(any(), any()) } returns uncached
+        every { cache.writeCacheFile(any()) } just Runs
 
-		scanner.calculateRenderSet(useCache = true)
+        scanner.calculateRenderSet(useCache = true)
 
-		// both new items should be persisted to the cache
-		verify { cache.writeCacheFile(match { items -> items.size == 2 }) }
-	}
+        // both new items should be persisted to the cache
+        verify { cache.writeCacheFile(match { items -> items.size == 2 }) }
+    }
 
-	@Test
-	fun `when caching is disabled the cache file is not loaded and an empty cached set is used`() {
-		every { changeSetCalculator.calculateUncachedSet(any(), any()) } returns emptySet()
-		every { cache.writeCacheFile(any()) } just Runs
+    @Test
+    fun `when caching is disabled the cache file is not loaded and an empty cached set is used`() {
+        every { changeSetCalculator.calculateUncachedSet(any(), any()) } returns emptySet()
+        every { cache.writeCacheFile(any()) } just Runs
 
-		scanner.calculateRenderSet(useCache = false)
+        scanner.calculateRenderSet(useCache = false)
 
-		verify(exactly = 0) { cache.loadCacheFile() }
-		verify { changeSetCalculator.calculateUncachedSet(emptySet(), emptySet()) }
-	}
+        verify(exactly = 0) { cache.loadCacheFile() }
+        verify { changeSetCalculator.calculateUncachedSet(emptySet(), emptySet()) }
+    }
 }

--- a/src/test/kotlin/org/liamjd/bascule/scanner/ScannerFunctionsTest.kt
+++ b/src/test/kotlin/org/liamjd/bascule/scanner/ScannerFunctionsTest.kt
@@ -129,21 +129,4 @@ class ScannerFunctionsTest {
 		assertEquals("b.html", a.mdCacheItem.next?.url)
 		assertEquals("b.html", c.mdCacheItem.previous?.url)
 	}
-
-	@Test
-	fun `non-post layouts are excluded from the navigation chain`() {
-		val page = post("about", LocalDate.of(2026, 1, 15), layout = "page")
-		val p1 = post("first", LocalDate.of(2026, 1, 1))
-		val p2 = post("second", LocalDate.of(2026, 2, 1))
-
-		val result = sortAndLinkPosts(setOf(page, p1, p2))
-
-		// the page is still in the sorted set ...
-		assertTrue(result.any { it.mdCacheItem.link.title == "about" })
-		// ... but is not linked, and the two posts link directly to each other
-		assertNull(page.mdCacheItem.previous)
-		assertNull(page.mdCacheItem.next)
-		assertEquals("second.html", p1.mdCacheItem.next?.url)
-		assertEquals("first.html", p2.mdCacheItem.previous?.url)
-	}
 }


### PR DESCRIPTION
This pull request improves date handling and template rendering, enhances error checking, and updates model conventions for Handlebars-based rendering. It also strengthens test coverage and consistency across the codebase.

### Date handling and template rendering

* The `HandlebarsRenderer` now injects the current date and time into the rendering model as `__nowDate` (`LocalDate.now()`) and `__now` (`LocalDateTime.now()`), making it easier to use the current date/time in templates.
* The `LocalDateFormatter` helper now enforces that only `Temporal` types are accepted, throwing an exception otherwise, and no longer returns the current date as a fallback. [[1]](diffhunk://#diff-5023003449bc778e9f3126ece12ccdb55e3df1b659f1a72388aac129c3d33fe1L20-R40) [[2]](diffhunk://#diff-5023003449bc778e9f3126ece12ccdb55e3df1b659f1a72388aac129c3d33fe1L47-L48)

### Model and naming consistency

* The special model key for the current page was changed from `$currentPage` to `__currentPage` in both the renderer and its tests, standardizing naming conventions. [[1]](diffhunk://#diff-e1e179545d640c669d475c4dc18c76e0eb1fd8f340a25280dc756d0956de38d9L38-R38) [[2]](diffhunk://#diff-9194f0b09c1a4ec4e23052053a147f2480ba2e54c383416f042b6cb0d52f7249L106-R103)

### Test coverage and robustness

* Added tests to ensure `LocalDateFormatter` throws an exception when passed a non-date, and correctly formats dates injected via `__nowDate`.
* Updated test imports for conciseness and improved comments for clarity. [[1]](diffhunk://#diff-9194f0b09c1a4ec4e23052053a147f2480ba2e54c383416f042b6cb0d52f7249L4-R4) [[2]](diffhunk://#diff-9194f0b09c1a4ec4e23052053a147f2480ba2e54c383416f042b6cb0d52f7249L21-R16) [[3]](diffhunk://#diff-0261d93483289cc4f7d3e917a54a669ddef1abe5bb2bef090017a949a9a886a8L3-R3)

### Minor cleanup

* Removed an obsolete test that checked navigation chain exclusion for non-post layouts.